### PR TITLE
Fix: Resolved Incorrect Alphabet Output On Export

### DIFF
--- a/finite-automata-designer/public/scripts/canvasUtil/canvasUtil.ts
+++ b/finite-automata-designer/public/scripts/canvasUtil/canvasUtil.ts
@@ -1,4 +1,3 @@
-import { alphabet, setAlphabet, transitionLabelInputValidator } from "../../../src/lib/nfa/nfaTransitionSymbols";
 import { ExportAsSVG } from "../exporting/ExportAsSVG";
 import { ExportAsLaTeX } from "../exporting/ExportAsLaTeX";
 import { Circle, circles} from "../Shapes/Circle";
@@ -12,6 +11,7 @@ export function saveAsSVG(
     textArea: HTMLTextAreaElement, 
     automationSpecification: string, 
     selectedObj: Circle | EntryArrow | Arrow | SelfArrow | null, 
+    alphabet: Set<string>,
     hightlightSelected: string, 
     base: string
 ) {
@@ -47,7 +47,8 @@ export function saveAsSVG(
 export function saveAsLaTeX(
     canvas: HTMLCanvasElement, 
     textArea: HTMLTextAreaElement, 
-    automationSpecification: string
+    automationSpecification: string,
+    alphabet: Set<string>
 ) {
   if (!canvas) return;
   

--- a/finite-automata-designer/public/scripts/canvasUtil/canvasUtil.ts
+++ b/finite-automata-designer/public/scripts/canvasUtil/canvasUtil.ts
@@ -3,7 +3,7 @@ import { ExportAsLaTeX } from "../exporting/ExportAsLaTeX";
 import { Circle, circles} from "../Shapes/Circle";
 import { Arrow, arrows} from "../Shapes/Arrow";
 import { SelfArrow} from "../Shapes/SelfArrow";
-import { EntryArrow, startState, setStartState} from "../Shapes/EntryArrow";
+import { EntryArrow, startState } from "../Shapes/EntryArrow";
 
 // Export the FSM as SVG
 export function saveAsSVG(

--- a/finite-automata-designer/public/scripts/dfa/dfaCanvas.ts
+++ b/finite-automata-designer/public/scripts/dfa/dfaCanvas.ts
@@ -625,7 +625,7 @@ function attachWhenReady() {
     if (exportSVGBtn) {
       exportSVGBtn.addEventListener('click', () => {
         if (canvas && outputTextArea) {
-          saveAsSVG(canvas, outputTextArea, "DFA", selectedObj, hightlightSelected, base);
+          saveAsSVG(canvas, outputTextArea, "DFA", selectedObj, alphabet, hightlightSelected, base);
         }
         if (outputContainer) {
           if (outputContainer.hidden) {
@@ -641,7 +641,7 @@ function attachWhenReady() {
     if (exportLaTeXBtn) {
       exportLaTeXBtn.addEventListener('click', () => {
         if (canvas && outputTextArea) {
-          saveAsLaTeX(canvas, outputTextArea, "DFA");
+          saveAsLaTeX(canvas, outputTextArea, "DFA", alphabet);
         }
         if (outputContainer) {
           if (outputContainer.hidden) {

--- a/finite-automata-designer/public/scripts/nfa/nfaCanvas.ts
+++ b/finite-automata-designer/public/scripts/nfa/nfaCanvas.ts
@@ -598,7 +598,7 @@ function attachWhenReady() {
     if (exportSVGBtn) {
       exportSVGBtn.addEventListener('click', () => {
         if (canvas && outputTextArea) {
-          saveAsSVG(canvas, outputTextArea, "NFA", selectedObj, hightlightSelected, base);
+          saveAsSVG(canvas, outputTextArea, "NFA", selectedObj, alphabet, hightlightSelected, base);
         }
         if (outputContainer) {
           if (outputContainer.hidden) {
@@ -614,7 +614,7 @@ function attachWhenReady() {
     if (exportLaTeXBtn) {
       exportLaTeXBtn.addEventListener('click', () => {
         if (canvas && outputTextArea) {
-          saveAsLaTeX(canvas, outputTextArea, "NFA");
+          saveAsLaTeX(canvas, outputTextArea, "NFA", alphabet);
         }
         if (outputContainer) {
           if (outputContainer.hidden) {


### PR DESCRIPTION
### Fix:
- Resolved issue #50 
- When exporting, we were originally using the alphabet from the NFA. So, whenever you exported a DFA, you were just using the default alphabet of the NFA, which was {0,1}. So, even though the DFA's alphabet was correct and functional, the exported alphabet was wrong
- This has been resolved by passing in the FA's corresponding alphabet into the saveAsSVG and saveAsLaTeX as a parameter
  - This was done on both the dfaCanvas and nfaCanvas