### PR TITLE
Refactor: Reusable Components for FA Editor Pages

### DIFF
--- a/finite-automata-designer/src/app/components/editor/AutomataHeader.tsx
+++ b/finite-automata-designer/src/app/components/editor/AutomataHeader.tsx
@@ -8,7 +8,7 @@ interface AutomataHeaderProps{
 
 export default function AutomataHeader({title, description = null}: AutomataHeaderProps){
     return (
-        <div>
+        <>
             <h1 className="text-5xl font-bold text-center my-2 text-black ">
                 <span className="drop-shadow-[0_0_1px_rgba(0,0,0,0.7)]">
                     {title}
@@ -30,7 +30,7 @@ export default function AutomataHeader({title, description = null}: AutomataHead
                     {description}
                 </p>
             )}
-        </div>
+        </>
 
     );
 }

--- a/finite-automata-designer/src/app/components/editor/AutomataHeader.tsx
+++ b/finite-automata-designer/src/app/components/editor/AutomataHeader.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+interface AutomataHeaderProps{
+    title: string;
+    description?: string | null;
+}
+
+
+export default function AutomataHeader({title, description = null}: AutomataHeaderProps){
+    return (
+        <div>
+            <h1 className="text-5xl font-bold text-center my-2 text-black ">
+                <span className="drop-shadow-[0_0_1px_rgba(0,0,0,0.7)]">
+                    {title}
+                </span>
+                <span className="h-8 bg-gradient-to-b from-white/30 via-white/10 to-transparent opacity-20 rounded pointer-events-none"></span>
+            </h1>
+            {description && (
+                <p
+                    className="
+                        mt-3
+                        max-w-3xl
+                        mx-auto
+                        px-4
+                        text-lg
+                        text-gray-600
+                        break-words
+                    "
+                >
+                    {description}
+                </p>
+            )}
+        </div>
+
+    );
+}

--- a/finite-automata-designer/src/app/components/editor/BackButton.tsx
+++ b/finite-automata-designer/src/app/components/editor/BackButton.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import Link from "next/link";
+
+export default function BackButton(){
+    return (
+        <Link 
+            href="/" 
+            className="px-6 py-3 bg-gray-700 text-white rounded hover:bg-black transition"
+        >
+            ← Back
+        </Link>
+    );
+}

--- a/finite-automata-designer/src/app/components/editor/ClearCanvasButton.tsx
+++ b/finite-automata-designer/src/app/components/editor/ClearCanvasButton.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+export default function ClearCanvasButton(){
+    return (
+        <div className="mt-4 flex justify-center">
+            <button
+                id="clearCanvas"
+                type="button"
+                className="bg-gray-700 text-white px-6 py-3 rounded hover:bg-gray-500 transition"
+            >
+                Clear Canvas
+            </button>
+        </div>
+    );
+}

--- a/finite-automata-designer/src/app/components/editor/ExportContainer.tsx
+++ b/finite-automata-designer/src/app/components/editor/ExportContainer.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { toggle_visiblity } from "../../../../public/scripts/canvasUtil/canvasUtil";
+
+export default function ExportContainer(){
+
+    const [exportOpen, setExportOpen] = useState(false);
+    
+    const exportMenuRef = useRef<HTMLDivElement>(null);
+    
+    return (
+        <div className="flex gap-2">
+            <p className="text-lg mt-5">Export as: </p> 
+            <div className="relative inline-block text-left mt-5">
+                {/* Exporting options parent selector*/}
+                <button
+                    id="exportMenuBtn"
+                    type="button"
+                    onClick={() => {
+                        if (exportMenuRef.current) toggle_visiblity(exportMenuRef.current);
+                        setExportOpen(prev => !prev);
+                    }}
+                    className="flex justify-center gap-x-1.5 rounded-md bg-gray-700 text-white px-2 py-1 text-md hover:bg-black transition"
+                >
+                    Export Options
+                    <svg
+                        className={`-mr-1 h-5 w-5 text-gray-400 h-4 w-4 transition-transform ${exportOpen ? "rotate-180" : ""}`}
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 20 20"
+                        fill="currentColor"
+                        aria-hidden="true"
+                    >
+                        <path
+                            fillRule="evenodd"
+                            d="M5.23 7.21a.75.75 0 011.06.02L10 10.939l3.71-3.71a.75.75 0 111.06 1.06l-4.24 4.24a.75.75 0 01-1.06 0L5.25 8.27a.75.75 0 01-.02-1.06z"
+                            clipRule="evenodd"
+                        />
+                    </svg>
+                </button>
+                
+                {/* Export Menu options (SVG and LaTeX)*/}
+                <div
+                    ref={exportMenuRef}
+                    id="exportMenu"
+                    hidden
+                    className="absolute mt-2 w-40 rounded-md bg-gray-700 shadow-lg z-20"
+                >
+                    <button
+                        id="svgExportBtn"
+                        type="button"
+                        onClick={() => {
+                            if (exportMenuRef.current) toggle_visiblity(exportMenuRef.current);
+                            setExportOpen(false);
+                        }}
+                        className="block w-full px-4 py-2 text-left text-white hover:bg-gray-600"
+                    >
+                        SVG
+                    </button>
+                    <button
+                        id="latexExportBtn"
+                        type="button"
+                        onClick={() => {
+                            if (exportMenuRef.current) toggle_visiblity(exportMenuRef.current);
+                            setExportOpen(false);
+                        }}
+                        className="block w-full px-4 py-2 text-left text-white hover:bg-gray-600"
+                    >
+                        LaTeX
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/finite-automata-designer/src/app/components/editor/ImportContainer.tsx
+++ b/finite-automata-designer/src/app/components/editor/ImportContainer.tsx
@@ -48,33 +48,33 @@ export default function ImportContainer(){
                         className="absolute mt-2 w-40 rounded-md bg-gray-700 shadow-lg z-20"
                     >
                         <button
-                        id="svgImportBtn"
-                        type="button"
-                        onClick={() => {
-                            if (importMenuRef.current) toggle_visiblity(importMenuRef.current);
-                            setImportOpen(false);
-                        }}
-                        className="block w-full px-4 py-2 text-left text-white hover:bg-gray-600"
+                            id="svgImportBtn"
+                            type="button"
+                            onClick={() => {
+                                if (importMenuRef.current) toggle_visiblity(importMenuRef.current);
+                                setImportOpen(false);
+                            }}
+                            className="block w-full px-4 py-2 text-left text-white hover:bg-gray-600"
                         >
-                        Import as SVG
+                            Import as SVG
                         </button>
                         <button
-                        id="latexImportBtn"
-                        type="button"
-                        onClick={() => {
-                            if (importMenuRef.current) toggle_visiblity(importMenuRef.current);
-                            setImportOpen(false);
-                        }}
-                        className="block w-full px-4 py-2 text-left text-white hover:bg-gray-600"
+                            id="latexImportBtn"
+                            type="button"
+                            onClick={() => {
+                                if (importMenuRef.current) toggle_visiblity(importMenuRef.current);
+                                setImportOpen(false);
+                            }}
+                            className="block w-full px-4 py-2 text-left text-white hover:bg-gray-600"
                         >
-                        Import as LaTeX
+                            Import as LaTeX
                         </button>
                     </div>
                 </div>
                 <button 
-                id="confirmImport"
-                className="flex justify-center gap-x-1.5 rounded-md bg-gray-700 text-white px-2 py-1 text-md hover:bg-black transition" 
-                hidden
+                    id="confirmImport"
+                    className="flex justify-center gap-x-1.5 rounded-md bg-gray-700 text-white px-2 py-1 text-md hover:bg-black transition" 
+                    hidden
                 >
                     Draw Import
                 </button>

--- a/finite-automata-designer/src/app/components/editor/ImportContainer.tsx
+++ b/finite-automata-designer/src/app/components/editor/ImportContainer.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { toggle_visiblity } from "../../../../public/scripts/canvasUtil/canvasUtil";
+
+
+export default function ImportContainer(){
+
+    const [importOpen, setImportOpen] = useState(false);
+    
+    const importMenuRef = useRef<HTMLDivElement>(null);
+
+    return (
+        <div className="flex gap-2 mt-2">
+            <p className="text-lg">Import as: </p> 
+            <div className="flex gap-2">
+                {/* Importing options parent selector*/}
+                <div className="relative inline-block text-left">
+                    <button
+                        id="importMenuBtn"
+                        type="button"
+                        onClick={() => {
+                            if (importMenuRef.current) toggle_visiblity(importMenuRef.current);
+                            setImportOpen(prev => !prev);
+                        }}
+                        className="flex justify-center gap-x-1.5 rounded-md bg-gray-700 text-white px-2 py-1 text-md hover:bg-black transition"
+                    >
+                        Import Options
+                        <svg
+                            className={`-mr-1 h-5 w-5 text-gray-400 h-4 w-4 transition-transform ${importOpen ? "rotate-180" : ""}`}
+                            xmlns="http://www.w3.org/2000/svg"
+                            viewBox="0 0 20 20"
+                            fill="currentColor"
+                            aria-hidden="true"
+                        >
+                            <path
+                                fillRule="evenodd"
+                                d="M5.23 7.21a.75.75 0 011.06.02L10 10.939l3.71-3.71a.75.75 0 111.06 1.06l-4.24 4.24a.75.75 0 01-1.06 0L5.25 8.27a.75.75 0 01-.02-1.06z"
+                                clipRule="evenodd"
+                            />
+                        </svg>
+                    </button>
+                    {/* Import Menu options (SVG and LaTeX)*/}
+                    <div
+                        ref={importMenuRef}
+                        id="importMenu"
+                        hidden
+                        className="absolute mt-2 w-40 rounded-md bg-gray-700 shadow-lg z-20"
+                    >
+                        <button
+                        id="svgImportBtn"
+                        type="button"
+                        onClick={() => {
+                            if (importMenuRef.current) toggle_visiblity(importMenuRef.current);
+                            setImportOpen(false);
+                        }}
+                        className="block w-full px-4 py-2 text-left text-white hover:bg-gray-600"
+                        >
+                        Import as SVG
+                        </button>
+                        <button
+                        id="latexImportBtn"
+                        type="button"
+                        onClick={() => {
+                            if (importMenuRef.current) toggle_visiblity(importMenuRef.current);
+                            setImportOpen(false);
+                        }}
+                        className="block w-full px-4 py-2 text-left text-white hover:bg-gray-600"
+                        >
+                        Import as LaTeX
+                        </button>
+                    </div>
+                </div>
+                <button 
+                id="confirmImport"
+                className="flex justify-center gap-x-1.5 rounded-md bg-gray-700 text-white px-2 py-1 text-md hover:bg-black transition" 
+                hidden
+                >
+                    Draw Import
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/finite-automata-designer/src/app/components/editor/InputString.tsx
+++ b/finite-automata-designer/src/app/components/editor/InputString.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+export default function InputString(){
+    
+    return (
+        <>
+            <label 
+                htmlFor="inputString" 
+                className="block mb-1 text-gray-700 text-xl font-bold"
+            >
+                Input:
+            </label>
+            <input
+                id="inputString"
+                type="text"
+                placeholder="Enter a string..."
+                className="w-full px-4 py-2 border border-gray-400 rounded shadow-sm bg-white focus:outline-none focus:ring-2 focus:ring-blue-400"
+                // Loose focus after you press enter
+                onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                        e.currentTarget.blur();
+                    }
+                }}
+            />
+        </>
+    );
+}

--- a/finite-automata-designer/src/app/components/editor/Instructions.tsx
+++ b/finite-automata-designer/src/app/components/editor/Instructions.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useState } from "react";
+
+interface InstructionsProps{
+    type: "DFA" | "NFA";
+}
+
+export function Instructions({ type }: InstructionsProps){
+
+    const [instructionsOpen, setInstructionsOpen] = useState(false);
+    
+    return (
+        <div className="mt-6 pr-4 w-full text-black">
+            <button
+                type="button"
+                onClick={() => setInstructionsOpen(prev => !prev)}
+                className="flex items-center gap-2 px-4 py-2 bg-gray-700 text-white rounded hover:bg-black transition"
+            >
+                Instructions
+                <svg
+                    className={`h-4 w-4 transition-transform ${instructionsOpen ? "rotate-180" : ""}`}
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
+                >
+                    <path 
+                        fillRule="evenodd" 
+                        d="M5.23 7.21a.75.75 0 011.06.02L10 10.939l3.71-3.71a.75.75 0 111.06 1.06l-4.24 4.24a.75.75 0 01-1.06 0L5.25 8.27a.75.75 0 01-.02-1.06z" 
+                        clipRule="evenodd" 
+                    />
+                </svg>
+            </button>
+            {instructionsOpen && (
+                <ul className="list-disc text-left mt-3 ml-4 text-sm space-y-1">
+                    <li><p className="font-semibold inline">Add a state: </p>Double-click on the canvas</li>
+                    <li><p className="font-semibold inline">Define start state: </p>Shift + Click empty space on canvas + Drag your desired start state</li>
+                    <li><p className="font-semibold inline">Add an arrow between states: </p>Shift + Click initial state + Drag the mouse to your desired terminal state</li>
+                    <li><p className="font-semibold inline">Add a looped arrow on a state: </p>Shift + Click existing state</li>
+                    <li><p className="font-semibold inline">Curve arrows: </p>Click your desired arrow and drag in the direction you wish to curve it</li>
+                    <li><p className="font-semibold inline">Move anything: </p>Click + Drag it around</li>
+                    <li><p className="font-semibold inline">Delete anything: </p>Click it and press the delete key (not backspace)</li>
+                    <li><p className="font-semibold inline">Make accept state: </p>Double-click an existing state</li>
+                    <li><p className="font-semibold inline">Type onto arrow or state: </p>Click on desired state, then begin typing. Click again anywhere else to submit</li>
+                    <li><p className="font-semibold inline">Type numeric subscript: </p>Put an underscore before the number (ex: &quot;q_0&quot;)</li>
+                    <li><p className="font-semibold inline">Set alphabet: </p>Type a comma-separated list of all the characters you wish to define for your DFA. Press Enter to submit</li>
+                    <li><p className="font-semibold inline">Run {type}: </p>Type an input string containing only the characters from your alphabet. Press Enter to submit</li>
+                </ul>
+            )}
+        </div>
+    );
+}

--- a/finite-automata-designer/src/app/components/editor/Instructions.tsx
+++ b/finite-automata-designer/src/app/components/editor/Instructions.tsx
@@ -6,7 +6,7 @@ interface InstructionsProps{
     type: "DFA" | "NFA";
 }
 
-export function Instructions({ type }: InstructionsProps){
+export default function Instructions({ type }: InstructionsProps){
 
     const [instructionsOpen, setInstructionsOpen] = useState(false);
     

--- a/finite-automata-designer/src/app/components/editor/ProjectsButton.tsx
+++ b/finite-automata-designer/src/app/components/editor/ProjectsButton.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import Link from "next/link";
+
+export default function ProjectsButton(){
+    return (
+        <Link
+            href="/projects"
+            className="flex-none px-8 py-3 bg-gray-700 text-white rounded hover:bg-black transition"
+        >
+            My Projects
+        </Link>
+    );
+}

--- a/finite-automata-designer/src/app/components/editor/RunButton.tsx
+++ b/finite-automata-designer/src/app/components/editor/RunButton.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+interface RunButton{
+    type: "DFA" | "NFA";
+}
+
+export default function RunButton({ type }: RunButton){
+    return (
+        <button
+            id={`${type.toLowerCase()}RunButton`}
+            type="button"
+            className="flex-none px-8 py-3 bg-gray-700 text-white rounded hover:bg-black transition"
+        >
+            Run
+        </button>
+    );
+}

--- a/finite-automata-designer/src/app/components/editor/RunButton.tsx
+++ b/finite-automata-designer/src/app/components/editor/RunButton.tsx
@@ -7,7 +7,7 @@ interface RunButton{
 export default function RunButton({ type }: RunButton){
     return (
         <button
-            id={`${type.toLowerCase()}RunButton`}
+            id={`${type.toLowerCase()}RunBtn`}
             type="button"
             className="flex-none px-8 py-3 bg-gray-700 text-white rounded hover:bg-black transition"
         >

--- a/finite-automata-designer/src/app/components/editor/SaveActions.tsx
+++ b/finite-automata-designer/src/app/components/editor/SaveActions.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+interface SaveActionsProps{
+    onSave: () => void;
+    onSaveAs?: () => void;
+}
+
+export default function SaveActions({
+    onSave,
+    onSaveAs,
+}: SaveActionsProps){
+    return (
+        <>
+            <button
+                type="button"
+                onClick={onSave}
+                className="flex-none px-8 py-3 bg-gray-700 text-white rounded hover:bg-black transition"
+            >
+                Save
+            </button>
+
+            {onSaveAs && (
+                <button
+                    type="button"
+                    onClick={onSaveAs}
+                    className="flex-none px-8 py-3 bg-gray-700 text-white rounded hover:bg-black transition"
+                >
+                    Save As New Project
+                </button>
+            )}
+        </>
+    );
+}

--- a/finite-automata-designer/src/app/components/editor/alphabet/AlphabetInput.tsx
+++ b/finite-automata-designer/src/app/components/editor/alphabet/AlphabetInput.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+export default function AlphabetInput(){
+
+    return (
+        <input
+            id="alphabet"
+            type="text"
+            placeholder="Enter an alphabet..."
+            className="w-full px-4 py-2 border border-gray-400 rounded shadow-sm bg-white focus:outline-none focus:ring-2 focus:ring-blue-400"
+            //onChange={(e) => setAlphabetDraft(e.target.value)}
+            // Loose focus after you press enter
+            onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                    e.currentTarget.blur();
+                    //setAlphabetInput(alphabetDraft.trim());
+                }
+            }}
+        />
+    );
+}

--- a/finite-automata-designer/src/app/components/editor/alphabet/AlphabetLabel.tsx
+++ b/finite-automata-designer/src/app/components/editor/alphabet/AlphabetLabel.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+interface AlphabetLabelProps{
+    hasMultiCharAlphabet: boolean;
+}
+
+export default function AlphabetLabel({ hasMultiCharAlphabet }: AlphabetLabelProps){
+    return (
+        <>
+            <div className="min-h-[3rem]">
+                {hasMultiCharAlphabet && (
+                    <div className="w-full rounded border border-red-300 bg-red-100 px-3 py-2">
+                        <p className="text-sm text-red-700 font-semibold">
+                            Multi-character element detected in alphabet. Please separate elements
+                            in your input string with commas or spaces.
+                        </p>
+                    </div>
+                )}
+            </div>
+            
+            {/* Textbox for inputting the alphabet */}
+            <label id="alphabetLabel" htmlFor="alphabet" className="block mb-1 text-gray-700 text-xl font-bold">
+                Alphabet: {"{0,1}"}
+            </label>
+        </>
+    );
+}

--- a/finite-automata-designer/src/app/components/editor/export/ExportContainer.tsx
+++ b/finite-automata-designer/src/app/components/editor/export/ExportContainer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRef, useState } from "react";
-import { toggle_visiblity } from "../../../../public/scripts/canvasUtil/canvasUtil";
+import { toggle_visiblity } from "../../../../../public/scripts/canvasUtil/canvasUtil";
 
 export default function ExportContainer(){
 

--- a/finite-automata-designer/src/app/components/editor/export/ExportTextArea.tsx
+++ b/finite-automata-designer/src/app/components/editor/export/ExportTextArea.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+export default function ExportTextArea(){
+
+    return (
+        <div id="exportOutputContainer" hidden className="text-center">
+            <textarea 
+                disabled
+                tabIndex={-1}
+                id="output"
+                className="w-full h-24 mt-2 border border-gray-400 rounded text-black bg-white select-none" 
+                placeholder="Export will appear here..."
+            >
+            </textarea>
+            <div className="flex gap-4 justify-center text-black">
+                <button 
+                    id='hideOutput' 
+                    type="button" 
+                    className="cursor-pointer text-center text-decoration underline"
+                >
+                    Hide Export Output
+                </button>
+                <button 
+                    id='copyOutput' 
+                    type="button" 
+                    className="cursor-pointer text-center text-decoration underline"
+                >
+                    Copy Output
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/finite-automata-designer/src/app/components/editor/import/ImportContainer.tsx
+++ b/finite-automata-designer/src/app/components/editor/import/ImportContainer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRef, useState } from "react";
-import { toggle_visiblity } from "../../../../public/scripts/canvasUtil/canvasUtil";
+import { toggle_visiblity } from "../../../../../public/scripts/canvasUtil/canvasUtil";
 
 
 export default function ImportContainer(){

--- a/finite-automata-designer/src/app/components/editor/import/ImportTextArea.tsx
+++ b/finite-automata-designer/src/app/components/editor/import/ImportTextArea.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+export default function ImportTextArea(){
+
+    return (
+        <div id="importInputContainer" hidden className="text-center">
+            <textarea 
+                tabIndex={-1}
+                id="input"
+                className="w-full h-24 mt-2 border border-gray-400 rounded text-black bg-white select-none" 
+                placeholder="Enter the input data that you exported EXCLUSIVELY from this FA designer goes here..."
+            >
+            </textarea>
+            <div className="flex gap-4 justify-center text-black">
+                <button 
+                    id='hideInput' 
+                    type="button" 
+                    className="cursor-pointer text-center text-decoration underline"
+                >
+                    Hide Input
+                </button>
+                <button 
+                    id='clearInput' 
+                    type="button" 
+                    className="cursor-pointer text-center text-decoration underline"
+                >
+                    Clear Input
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/finite-automata-designer/src/app/components/projects/DeleteProjectModal.tsx
+++ b/finite-automata-designer/src/app/components/projects/DeleteProjectModal.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useState } from "react";
+
 interface DeleteProjectModalProps{
     name: string;
     onDelete: () => Promise<void>;
@@ -11,9 +13,88 @@ export function DeleteProjectModal({
     onDelete,
     onCancel,
 }: DeleteProjectModalProps){
+    const [isDeleting, setIsDeleting] = useState(false);
+
+    const handleDeleteClick = async () => {
+        try {
+            setIsDeleting(true);
+            await onDelete();
+        } finally {
+            setIsDeleting(false);
+        }
+    };
+
     return (
-        <div>
-            DeleteProject!
+        <div
+            className="
+                fixed inset-0 z-50
+                flex items-center justify-center
+                bg-black/50
+            "
+        >
+            <div
+                className="
+                    bg-white
+                    rounded-xl
+                    shadow-xl
+                    w-full
+                    max-w-md
+                    p-6
+                    space-y-6
+                "
+            >
+                <div>
+                    <h2 className="text-2xl font-bold text-gray-800">
+                        Delete Project
+                    </h2>
+
+                    <p className="mt-2 text-gray-600">
+                        Are you sure you want to delete{" "}
+                        <span className="font-semibold">
+                            {`"${name}"`}
+                        </span>
+                        ?
+                    </p>
+
+                    <p className="mt-2 text-sm text-red-600">
+                        This action cannot be undone.
+                    </p>
+                </div>
+
+                <div className="flex justify-end gap-3">
+                    <button
+                        type="button"
+                        onClick={onCancel}
+                        disabled={isDeleting}
+                        className="
+                            px-4 py-2
+                            rounded-lg
+                            border border-gray-300
+                            text-gray-700
+                            hover:bg-gray-100
+                            disabled:opacity-50
+                        "
+                    >
+                        Cancel
+                    </button>
+
+                    <button
+                        type="button"
+                        onClick={handleDeleteClick}
+                        disabled={isDeleting}
+                        className="
+                            px-4 py-2
+                            rounded-lg
+                            bg-red-600
+                            text-white
+                            hover:bg-red-700
+                            disabled:opacity-50
+                        "
+                    >
+                        {isDeleting ? "Deleting..." : "Delete"}
+                    </button>
+                </div>
+            </div>
         </div>
     );
 }

--- a/finite-automata-designer/src/app/components/projects/DeleteProjectModal.tsx
+++ b/finite-automata-designer/src/app/components/projects/DeleteProjectModal.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+interface DeleteProjectModalProps{
+    name: string;
+    onDelete: () => Promise<void>;
+    onCancel: () => void;
+}
+
+export function DeleteProjectModal({
+    name,
+    onDelete,
+    onCancel,
+}: DeleteProjectModalProps){
+    return (
+        <div>
+            DeleteProject!
+        </div>
+    );
+}

--- a/finite-automata-designer/src/app/components/projects/DeleteProjectModal.tsx
+++ b/finite-automata-designer/src/app/components/projects/DeleteProjectModal.tsx
@@ -5,13 +5,13 @@ import { useState } from "react";
 interface DeleteProjectModalProps{
     name: string;
     onDelete: () => Promise<void>;
-    onCancel: () => void;
+    onClose: () => void;
 }
 
 export function DeleteProjectModal({
     name,
     onDelete,
-    onCancel,
+    onClose,
 }: DeleteProjectModalProps){
     const [isDeleting, setIsDeleting] = useState(false);
 
@@ -19,7 +19,12 @@ export function DeleteProjectModal({
         try {
             setIsDeleting(true);
             await onDelete();
-        } finally {
+        } 
+        catch(error){
+            console.error(error);
+            alert("Failed to delete project: " + error);
+        }
+        finally {
             setIsDeleting(false);
         }
     };
@@ -64,7 +69,7 @@ export function DeleteProjectModal({
                 <div className="flex justify-end gap-3">
                     <button
                         type="button"
-                        onClick={onCancel}
+                        onClick={onClose}
                         disabled={isDeleting}
                         className="
                             px-4 py-2

--- a/finite-automata-designer/src/app/components/projects/EditProjectModal.tsx
+++ b/finite-automata-designer/src/app/components/projects/EditProjectModal.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useState } from "react";
+
+interface EditProjectModalProps{
+    initialName: string;
+    initialDescription: string | null;
+    onEdit: () => Promise<void>;
+    onCancel: () => void;
+}
+
+export function EditProjectModal({
+    initialName,
+    initialDescription,
+    onEdit,
+    onCancel,
+}: EditProjectModalProps){
+    const [name, setName] = useState(initialName);
+    const [description, setDescription] = useState(initialDescription ?? "");
+    const [isEditing, setIsEditing] = useState(false);
+
+    return (
+        <div>
+            Edit Project Modal!
+        </div>
+    );
+}

--- a/finite-automata-designer/src/app/components/projects/EditProjectModal.tsx
+++ b/finite-automata-designer/src/app/components/projects/EditProjectModal.tsx
@@ -1,27 +1,205 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 interface EditProjectModalProps{
+    id: string;
     initialName: string;
     initialDescription: string | null;
-    onEdit: () => Promise<void>;
-    onCancel: () => void;
+    onSave: (id: string, name: string, description: string) => Promise<void>;
+    onClose: () => void;
 }
 
 export function EditProjectModal({
+    id,
     initialName,
-    initialDescription,
-    onEdit,
-    onCancel,
+    initialDescription = null,
+    onSave,
+    onClose,
 }: EditProjectModalProps){
     const [name, setName] = useState(initialName);
     const [description, setDescription] = useState(initialDescription ?? "");
-    const [isEditing, setIsEditing] = useState(false);
+    const [isSaving, setIsSaving] = useState(false);
+
+    useEffect(() => {
+        setName(initialName ?? "");
+    }, [initialName]);
+
+    useEffect(() => {
+        setDescription(initialDescription ?? "");
+    }, [initialDescription]);
+
+    const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        try{
+            setIsSaving(true);
+            await onSave(id, name, description);
+        }
+        catch(error){
+            console.error(error);
+            alert("Failed to save changes: " + error);
+        }
+        finally{
+            setIsSaving(false);
+            onClose();
+        }
+
+    };
 
     return (
-        <div>
-            Edit Project Modal!
+        <div
+            className="
+                fixed inset-0 z-50
+                flex items-center justify-center
+                bg-black/50
+                backdrop-blur-sm
+                p-4
+            "
+        >
+            <div
+                className="
+                    w-full max-w-lg
+                    bg-white
+                    rounded-2xl
+                    shadow-2xl
+                    p-6
+                    animate-in fade-in zoom-in duration-200
+                "
+            >
+                <div className="flex items-center justify-between mb-6">
+                    <h2 className="text-2xl font-bold text-gray-800">
+                        Save Project
+                    </h2>
+
+                    <button
+                        onClick={onClose}
+                        className="
+                            text-gray-500
+                            hover:text-gray-800
+                            text-2xl
+                            transition
+                        "
+                    >
+                        ×
+                    </button>
+                </div>
+
+                <form className="space-y-5"
+                    onSubmit={handleSubmit}
+                >
+                    <div>
+                        <label
+                            htmlFor="project-name"
+                            className="
+                                block
+                                text-sm
+                                font-semibold
+                                text-gray-700
+                                mb-2
+                            "
+                        >
+                            Project Name
+                        </label>
+
+                        <input
+                            id="project-name"
+                            disabled={isSaving}
+                            type="text"
+                            value={name}
+                            onChange={(e) => setName(e.target.value)}
+                            placeholder="Enter project name..."
+                            className="
+                                w-full
+                                rounded-lg
+                                border
+                                border-gray-300
+                                px-4
+                                py-3
+                                text-gray-800
+                                focus:outline-none
+                                focus:ring-2
+                                focus:ring-blue-500
+                                focus:border-transparent
+                            "
+                        />
+                    </div>
+
+                    <div>
+                        <label
+                            htmlFor="project-description"
+                            className="
+                                block
+                                text-sm
+                                font-semibold
+                                text-gray-700
+                                mb-2
+                            "
+                        >
+                            Description
+                        </label>
+
+                        <textarea
+                            id="project-description"
+                            disabled={isSaving}
+                            value={description}
+                            onChange={(e) => setDescription(e.target.value)}
+                            placeholder="Optional description..."
+                            rows={4}
+                            className="
+                                w-full
+                                rounded-lg
+                                border
+                                border-gray-300
+                                px-4
+                                py-3
+                                text-gray-800
+                                resize-none
+                                focus:outline-none
+                                focus:ring-2
+                                focus:ring-blue-500
+                                focus:border-transparent
+                            "
+                        />
+                    </div>
+
+                    <div className="flex justify-end gap-3 pt-4">
+                        <button
+                            type="button"
+                            disabled={isSaving}
+                            onClick={onClose}
+                            className="
+                                px-5 py-2.5
+                                rounded-lg
+                                border
+                                border-gray-300
+                                text-gray-700
+                                hover:bg-gray-100
+                                transition
+                            "
+                        >
+                            Cancel
+                        </button>
+
+                        <button
+                            type="submit"
+                            disabled={isSaving}
+                            className="
+                                px-5 py-2.5
+                                rounded-lg
+                                bg-blue-600
+                                text-white
+                                font-semibold
+                                hover:bg-blue-700
+                                disabled:opacity-50
+                                disabled:cursor-not-allowed
+                                transition
+                            "
+                        >
+                            Save
+                        </button>
+                    </div>
+                </form>
+            </div>
         </div>
     );
 }

--- a/finite-automata-designer/src/app/components/projects/ProjectCard.tsx
+++ b/finite-automata-designer/src/app/components/projects/ProjectCard.tsx
@@ -16,8 +16,7 @@ export default function ProjectCard({
     type
 }: ProjectCardProps) {
     return (
-        <Link 
-            href={`/${type.toLowerCase()}/${id}`}
+        <div
             className="
                 bg-white
                 rounded-xl
@@ -34,34 +33,39 @@ export default function ProjectCard({
                 hover:-translate-y-1
             "
         >
-            <div className="flex items-start justify-between">
-                <h2 className="text-2xl font-bold text-gray-800 break-words">
-                    {name}
-                </h2>
+            <Link
+                href={`/${type.toLowerCase()}/${id}`}
+                className="flex flex-col gap-4"
+            >
+                <div className="flex items-start justify-between">
+                    <h2 className="text-2xl font-bold text-gray-800 break-words">
+                        {name}
+                    </h2>
 
-                <span
-                    className={`
-                        px-3 py-1 rounded-full text-sm font-semibold
-                        ${
-                            type === "DFA"
-                                ? "bg-blue-100 text-blue-700"
-                                : "bg-purple-100 text-purple-700"
-                        }
-                    `}
-                >
-                    {type}
-                </span>
-            </div>
+                    <span
+                        className={`
+                            px-3 py-1 rounded-full text-sm font-semibold
+                            ${
+                                type === "DFA"
+                                    ? "bg-blue-100 text-blue-700"
+                                    : "bg-purple-100 text-purple-700"
+                            }
+                        `}
+                    >
+                        {type}
+                    </span>
+                </div>
 
-            <p className="text-gray-600 flex-grow">
-                {description || "No description provided."}
-            </p>
-
-            <div className="pt-2 border-t border-gray-100">
-                <p className="text-sm text-gray-400 truncate">
-                    ID: {id}
+                <p className="text-gray-600 flex-grow">
+                    {description || "No description provided."}
                 </p>
-            </div>
-        </Link>
+
+                <div className="pt-2 border-t border-gray-100">
+                    <p className="text-sm text-gray-400 truncate">
+                        ID: {id}
+                    </p>
+                </div>
+            </Link>
+        </div>
     );
 }

--- a/finite-automata-designer/src/app/components/projects/ProjectCard.tsx
+++ b/finite-automata-designer/src/app/components/projects/ProjectCard.tsx
@@ -7,6 +7,7 @@ interface ProjectCardProps {
     name: string;
     description: string | null;
     type: string;
+    onEdit: () => void;
     onDelete: () => void;
 }
 
@@ -15,7 +16,8 @@ export default function ProjectCard({
     name,
     description,
     type,
-    onDelete
+    onEdit,
+    onDelete,
 }: ProjectCardProps) {
     return (
         <div
@@ -70,6 +72,22 @@ export default function ProjectCard({
             </Link>
 
             <div className="flex gap-3 pt-2">
+                <button
+                    type="button"
+                    onClick={onEdit}
+                    className="
+                        flex-1
+                        px-4
+                        py-2
+                        rounded-lg
+                        bg-blue-500
+                        text-white
+                        hover:bg-red-600
+                        transition
+                    "
+                >
+                    Edit
+                </button>
 
                 <button
                     type="button"

--- a/finite-automata-designer/src/app/components/projects/ProjectCard.tsx
+++ b/finite-automata-designer/src/app/components/projects/ProjectCard.tsx
@@ -16,8 +16,8 @@ export default function ProjectCard({
     type
 }: ProjectCardProps) {
     return (
-        <Link
-            href={`/dfa?id=${id}`}
+        <Link 
+            href={`/${type.toLowerCase()}/${id}`}
             className="
                 bg-white
                 rounded-xl

--- a/finite-automata-designer/src/app/components/projects/ProjectCard.tsx
+++ b/finite-automata-designer/src/app/components/projects/ProjectCard.tsx
@@ -7,13 +7,15 @@ interface ProjectCardProps {
     name: string;
     description: string | null;
     type: string;
+    onDelete: () => void;
 }
 
 export default function ProjectCard({
     id,
     name,
     description,
-    type
+    type,
+    onDelete
 }: ProjectCardProps) {
     return (
         <div
@@ -66,6 +68,26 @@ export default function ProjectCard({
                     </p>
                 </div>
             </Link>
+
+            <div className="flex gap-3 pt-2">
+
+                <button
+                    type="button"
+                    onClick={onDelete}
+                    className="
+                        flex-1
+                        px-4
+                        py-2
+                        rounded-lg
+                        bg-red-500
+                        text-white
+                        hover:bg-red-600
+                        transition
+                    "
+                >
+                    Delete
+                </button>
+            </div>
         </div>
     );
 }

--- a/finite-automata-designer/src/app/components/projects/ProjectCard.tsx
+++ b/finite-automata-designer/src/app/components/projects/ProjectCard.tsx
@@ -2,33 +2,63 @@
 
 import Link from "next/link";
 
-interface ProjectCardProps{
+interface ProjectCardProps {
     id: string;
     name: string;
     description: string | null;
     type: string;
 }
 
-export async function ProjectCard({id, name, description, type}: ProjectCardProps){
+export default function ProjectCard({
+    id,
+    name,
+    description,
+    type
+}: ProjectCardProps) {
     return (
         <Link
             href={`/dfa?id=${id}`}
+            className="
+                bg-white
+                rounded-xl
+                shadow-md
+                hover:shadow-xl
+                transition-all
+                duration-200
+                border
+                border-gray-200
+                p-6
+                flex
+                flex-col
+                gap-4
+                hover:-translate-y-1
+            "
         >
-            <div>
-                <h2>
+            <div className="flex items-start justify-between">
+                <h2 className="text-2xl font-bold text-gray-800 break-words">
                     {name}
                 </h2>
-                <span>
+
+                <span
+                    className={`
+                        px-3 py-1 rounded-full text-sm font-semibold
+                        ${
+                            type === "DFA"
+                                ? "bg-blue-100 text-blue-700"
+                                : "bg-purple-100 text-purple-700"
+                        }
+                    `}
+                >
                     {type}
                 </span>
             </div>
 
-            <p>
+            <p className="text-gray-600 flex-grow">
                 {description || "No description provided."}
             </p>
 
-            <div>
-                <p>
+            <div className="pt-2 border-t border-gray-100">
+                <p className="text-sm text-gray-400 truncate">
                     ID: {id}
                 </p>
             </div>

--- a/finite-automata-designer/src/app/components/projects/ProjectCard.tsx
+++ b/finite-automata-designer/src/app/components/projects/ProjectCard.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import Link from "next/link";
+
+interface ProjectCardProps{
+    id: string;
+    name: string;
+    description: string | null;
+    type: string;
+}
+
+export async function ProjectCard({id, name, description, type}: ProjectCardProps){
+    return (
+        <Link
+            href={`/dfa?id=${id}`}
+        >
+            <div>
+                <h2>
+                    {name}
+                </h2>
+                <span>
+                    {type}
+                </span>
+            </div>
+
+            <p>
+                {description || "No description provided."}
+            </p>
+
+            <div>
+                <p>
+                    ID: {id}
+                </p>
+            </div>
+        </Link>
+    );
+}

--- a/finite-automata-designer/src/app/components/projects/SaveProjectModal.tsx
+++ b/finite-automata-designer/src/app/components/projects/SaveProjectModal.tsx
@@ -25,19 +25,153 @@ export function SaveProjectModal({
     }
 
     return (
-        <div>
-            Save Project!!
-            <div>
-                Name: {name}
-            </div>
-            <div>
-                Description: {description}
-            </div>
-            <button
-                onClick={onClose}
+        <div
+            className="
+                fixed inset-0 z-50
+                flex items-center justify-center
+                bg-black/50
+                backdrop-blur-sm
+                p-4
+            "
+        >
+            <div
+                className="
+                    w-full max-w-lg
+                    bg-white
+                    rounded-2xl
+                    shadow-2xl
+                    p-6
+                    animate-in fade-in zoom-in duration-200
+                "
             >
-                Cancel
-            </button>
+                <div className="flex items-center justify-between mb-6">
+                    <h2 className="text-2xl font-bold text-gray-800">
+                        Save Project
+                    </h2>
+
+                    <button
+                        onClick={onClose}
+                        className="
+                            text-gray-500
+                            hover:text-gray-800
+                            text-2xl
+                            transition
+                        "
+                    >
+                        ×
+                    </button>
+                </div>
+
+                <form className="space-y-5">
+                    <div>
+                        <label
+                            htmlFor="project-name"
+                            className="
+                                block
+                                text-sm
+                                font-semibold
+                                text-gray-700
+                                mb-2
+                            "
+                        >
+                            Project Name
+                        </label>
+
+                        <input
+                            id="project-name"
+                            type="text"
+                            value={name}
+                            onChange={(e) => setName(e.target.value)}
+                            placeholder="Enter project name..."
+                            className="
+                                w-full
+                                rounded-lg
+                                border
+                                border-gray-300
+                                px-4
+                                py-3
+                                text-gray-800
+                                focus:outline-none
+                                focus:ring-2
+                                focus:ring-blue-500
+                                focus:border-transparent
+                            "
+                        />
+                    </div>
+
+                    <div>
+                        <label
+                            htmlFor="project-description"
+                            className="
+                                block
+                                text-sm
+                                font-semibold
+                                text-gray-700
+                                mb-2
+                            "
+                        >
+                            Description
+                        </label>
+
+                        <textarea
+                            id="project-description"
+                            value={description}
+                            onChange={(e) => setDescription(e.target.value)}
+                            placeholder="Optional description..."
+                            rows={4}
+                            className="
+                                w-full
+                                rounded-lg
+                                border
+                                border-gray-300
+                                px-4
+                                py-3
+                                text-gray-800
+                                resize-none
+                                focus:outline-none
+                                focus:ring-2
+                                focus:ring-blue-500
+                                focus:border-transparent
+                            "
+                        />
+                    </div>
+
+                    <div className="flex justify-end gap-3 pt-4">
+                        <button
+                            type="button"
+                            onClick={onClose}
+                            className="
+                                px-5 py-2.5
+                                rounded-lg
+                                border
+                                border-gray-300
+                                text-gray-700
+                                hover:bg-gray-100
+                                transition
+                            "
+                        >
+                            Cancel
+                        </button>
+
+                        <button
+                            type="submit"
+                            className="
+                                px-5 py-2.5
+                                rounded-lg
+                                bg-blue-600
+                                text-white
+                                font-semibold
+                                hover:bg-blue-700
+                                disabled:opacity-50
+                                disabled:cursor-not-allowed
+                                transition
+                            "
+                        >
+                            Save
+                        </button>
+                    </div>
+                </form>
+            </div>
         </div>
     );
 }

--- a/finite-automata-designer/src/app/components/projects/SaveProjectModal.tsx
+++ b/finite-automata-designer/src/app/components/projects/SaveProjectModal.tsx
@@ -4,21 +4,21 @@ import { useState } from "react";
 
 interface SaveProjectModalProps{
     isOpen: boolean;
-    initialName?: string;
-    initialDescription?: string;
+    initialName: string | null;
+    initialDescription: string | null;
     onClose: () => void;
     onSave: (name: string, description: string) => Promise<void>;
 }
 
 export function SaveProjectModal({
     isOpen,
-    initialName = "", 
-    initialDescription = "",
+    initialName = null, 
+    initialDescription = null,
     onClose,
     onSave,
 }: SaveProjectModalProps){
-    const [name, setName] = useState(initialName);
-    const [description, setDescription] = useState(initialDescription);
+    const [name, setName] = useState((initialName === null) ? "" : initialName);
+    const [description, setDescription] = useState((initialDescription === null) ? "" : initialDescription);
 
     if(!isOpen){
         return null;
@@ -62,7 +62,9 @@ export function SaveProjectModal({
                     </button>
                 </div>
 
-                <form className="space-y-5">
+                <form className="space-y-5"
+                    onSubmit={handleSubmit}
+                >
                     <div>
                         <label
                             htmlFor="project-name"

--- a/finite-automata-designer/src/app/components/projects/SaveProjectModal.tsx
+++ b/finite-automata-designer/src/app/components/projects/SaveProjectModal.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useState } from "react";
+
+interface SaveProjectModalProps{
+    isOpen: boolean;
+    initialName?: string;
+    initialDescription?: string;
+    onClose: () => void;
+    onSave: (name: string, description: string) => Promise<void>;
+}
+
+export function SaveProjectModal({
+    isOpen,
+    initialName = "", 
+    initialDescription = "",
+    onClose,
+    onSave,
+}: SaveProjectModalProps){
+    const [name, setName] = useState(initialName);
+    const [description, setDescription] = useState(initialDescription);
+
+    if(!isOpen){
+        return null;
+    }
+
+    return (
+        <div>
+            Save Project!!
+            <div>
+                Name: {name}
+            </div>
+            <div>
+                Description: {description}
+            </div>
+            <button
+                onClick={onClose}
+            >
+                Cancel
+            </button>
+        </div>
+    );
+}

--- a/finite-automata-designer/src/app/components/projects/SaveProjectModal.tsx
+++ b/finite-automata-designer/src/app/components/projects/SaveProjectModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 interface SaveProjectModalProps{
     isOpen: boolean;
@@ -19,6 +19,14 @@ export function SaveProjectModal({
 }: SaveProjectModalProps){
     const [name, setName] = useState((initialName === null) ? "" : initialName);
     const [description, setDescription] = useState((initialDescription === null) ? "" : initialDescription);
+
+    useEffect(() => {
+        setName(initialName ?? "");
+    }, [initialName]);
+
+    useEffect(() => {
+        setDescription(initialDescription ?? "");
+    }, [initialDescription]);
 
     const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();

--- a/finite-automata-designer/src/app/components/projects/SaveProjectModal.tsx
+++ b/finite-automata-designer/src/app/components/projects/SaveProjectModal.tsx
@@ -20,6 +20,21 @@ export function SaveProjectModal({
     const [name, setName] = useState((initialName === null) ? "" : initialName);
     const [description, setDescription] = useState((initialDescription === null) ? "" : initialDescription);
 
+    const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        try{
+            await onSave(name, description);
+        }
+        catch(error){
+            console.error(error);
+            alert("Failed to save changes: " + error);
+        }
+        finally{
+            onClose();
+        }
+
+    };
+
     if(!isOpen){
         return null;
     }

--- a/finite-automata-designer/src/app/dfa/[id]/page.tsx
+++ b/finite-automata-designer/src/app/dfa/[id]/page.tsx
@@ -67,7 +67,6 @@ function DFAPageContent() {
             setName(finiteAutomatonData.name);
             setDescription(finiteAutomatonData.description);
 
-
             if (typeof window.loadDFAIntoCanvas === 'function') {
                 // Canvas script is already loaded — call directly.
                 window.loadDFAIntoCanvas(finiteAutomatonData.automaton);
@@ -116,10 +115,25 @@ function DFAPageContent() {
         {/* DFA title at the top */}
         <h1 className="text-5xl font-bold text-center my-2 text-black ">
             <span className="drop-shadow-[0_0_1px_rgba(0,0,0,0.7)]">
-                Deterministic Finite Automata
+                DFA: {name}
             </span>
             <span className="h-8 bg-gradient-to-b from-white/30 via-white/10 to-transparent opacity-20 rounded pointer-events-none"></span>
         </h1>
+        {description && (
+            <p
+                className="
+                    mt-3
+                    max-w-3xl
+                    mx-auto
+                    px-4
+                    text-lg
+                    text-gray-600
+                    break-words
+                "
+            >
+                {description}
+            </p>
+        )}
         <div
             className="flex w-full"
         >

--- a/finite-automata-designer/src/app/dfa/[id]/page.tsx
+++ b/finite-automata-designer/src/app/dfa/[id]/page.tsx
@@ -14,6 +14,7 @@ import ExportContainer from "@/app/components/editor/export/ExportContainer";
 import ExportTextArea from "@/app/components/editor/export/ExportTextArea";
 import InputString from "@/app/components/editor/InputString";
 import AlphabetInput from "@/app/components/editor/alphabet/AlphabetInput";
+import AlphabetLabel from "@/app/components/editor/alphabet/AlphabetLabel";
 
 
 function DFAPageContent() {
@@ -166,20 +167,9 @@ function DFAPageContent() {
                             {/* Textbox for inputting strings */}
                             <InputString />
 
-                            <div className="min-h-[3rem]">
-                                {hasMultiCharAlphabet && (
-                                    <div className="w-full rounded border border-red-300 bg-red-100 px-3 py-2">
-                                        <p className="text-sm text-red-700 font-semibold">
-                                            Multi-character element detected in alphabet. Please separate elements
-                                            in your input string with commas or spaces.
-                                        </p>
-                                    </div>
-                                )}
-                            </div>
-                            {/* Textbox for inputting the alphabet */}
-                            <label id="alphabetLabel" htmlFor="alphabet" className="block mb-1 text-gray-700 text-xl font-bold">
-                                Alphabet: {"{0,1}"}
-                            </label>
+                            <AlphabetLabel 
+                                hasMultiCharAlphabet={hasMultiCharAlphabet}
+                            />
                             
                             <AlphabetInput />
                         </div>

--- a/finite-automata-designer/src/app/dfa/[id]/page.tsx
+++ b/finite-automata-designer/src/app/dfa/[id]/page.tsx
@@ -151,18 +151,7 @@ function DFAPageContent() {
                     
                     <ExportTextArea />
 
-                    <div id="importInputContainer" hidden className="text-center">
-                        <textarea 
-                        tabIndex={-1}
-                        id="input"
-                        className="w-full h-24 mt-2 border border-gray-400 rounded text-black bg-white select-none" 
-                        placeholder="Enter the input data that you exported EXCLUSIVELY from this FA designer goes here...">
-                        </textarea>
-                        <div className="flex gap-4 justify-center text-black">
-                            <button id='hideInput' type="button" className="cursor-pointer text-center text-decoration underline">Hide Input</button>
-                            <button id='clearInput' type="button" className="cursor-pointer text-center text-decoration underline">Clear Input</button>
-                        </div>
-                    </div>
+                    
                 
                 </div>
             </div>

--- a/finite-automata-designer/src/app/dfa/[id]/page.tsx
+++ b/finite-automata-designer/src/app/dfa/[id]/page.tsx
@@ -134,12 +134,13 @@ function DFAPageContent() {
                 {/* Back Button to return to Home Page */}
                 <BackButton />
 
+                {/* Instructions dropdown */}
                 <Instructions 
                     type={"DFA"}
                 />
 
             </div>
-            
+
             {/* Canvas parent div*/}
             <div>
                 <div id="canvasDiv" className="flex flex-col text-black">
@@ -152,9 +153,10 @@ function DFAPageContent() {
                     {/* Importing dropdowns container*/}
                     <ImportContainer />
 
-                    
+                    {/* Exporting text area */}
                     <ExportTextArea />
 
+                    {/* Importing text area */}
                     <ImportTextArea />
 
                 </div>
@@ -168,10 +170,12 @@ function DFAPageContent() {
                             {/* Textbox for inputting strings */}
                             <InputString />
 
+                            {/* Alphabet display */}
                             <AlphabetLabel 
                                 hasMultiCharAlphabet={hasMultiCharAlphabet}
                             />
                             
+                            {/* Input box for new alphabet */}
                             <AlphabetInput />
 
                         </div>

--- a/finite-automata-designer/src/app/dfa/[id]/page.tsx
+++ b/finite-automata-designer/src/app/dfa/[id]/page.tsx
@@ -7,6 +7,7 @@ import { toggle_visiblity } from "../../../../public/scripts/canvasUtil/canvasUt
 import { saveAutomaton, updateAutomaton } from "@/lib/automata/mutations";
 import { FiniteAutomaton } from "@/lib/shared/types";
 import { getAutomaton } from "@/lib/automata/queries";
+import { SaveProjectModal } from "@/app/components/projects/SaveProjectModal";
 
 
 function DFAPageContent() {
@@ -17,6 +18,8 @@ function DFAPageContent() {
     const [exportOpen, setExportOpen] = useState(false);
     const [importOpen, setImportOpen] = useState(false);
     const [isSaving, setIsSaving] = useState(false);
+    const [name, setName] = useState<string | null>(null);
+    const [description, setDescription] = useState<string | null>(null);
 
     const params = useParams();
 
@@ -60,6 +63,9 @@ function DFAPageContent() {
             }
 
             const finiteAutomatonData: FiniteAutomaton = await getAutomaton(automatonId);
+            setName(finiteAutomatonData.name);
+            setDescription(finiteAutomatonData.description);
+
 
             if (typeof window.loadDFAIntoCanvas === 'function') {
                 // Canvas script is already loaded — call directly.
@@ -74,13 +80,13 @@ function DFAPageContent() {
         loadAutomaton();
     },[automatonId]);
 
-    async function handleSaveAsNew(name: string, description: string){
+    async function handleSaveAsNew(newName: string, newDescription: string){
 
         const serialized = window.exportDFA();
         console.log(serialized);
 
         try{
-            await saveAutomaton(serialized, name, description);
+            await saveAutomaton(serialized, newName, newDescription);
             alert("Automaton saved!");
         }
         catch (err) {
@@ -434,6 +440,14 @@ function DFAPageContent() {
                 </div>
             </div>
         </div>
+
+        <SaveProjectModal
+            isOpen={isSaving}
+            initialName={name}
+            initialDescription={description}
+            onClose={() => setIsSaving(false)}
+            onSave={handleSaveAsNew}
+        />
 
         <Script
             src="/scripts/dfa/dfaCanvas.js"

--- a/finite-automata-designer/src/app/dfa/[id]/page.tsx
+++ b/finite-automata-designer/src/app/dfa/[id]/page.tsx
@@ -139,6 +139,7 @@ function DFAPageContent() {
                 />
 
             </div>
+            
             {/* Canvas parent div*/}
             <div>
                 <div id="canvasDiv" className="flex flex-col text-black">
@@ -150,16 +151,7 @@ function DFAPageContent() {
 
                     {/* Importing dropdowns container*/}
                     <ImportContainer />
-                    
-                    {/*Leave for now in case we turn back the UI for importing and exporting*/}
 
-                    {/* <div className="text-center text-black mt-2">
-                        Export as: <button id='svgExportBtn' type="button" className="cursor-pointer">SVG</button>
-                        {' | '} <button id='latexExportBtn' type="button" className="cursor-pointer">LaTeX</button>
-                        <br />
-                        Import as: <button id='svgImportBtn' type="button" className="cursor-pointer">SVG</button>
-                        {' | '} <button id='latexImportBtn' type="button" className="cursor-pointer">LaTeX</button>
-                    </div> */}
                     
                     <ExportTextArea />
 

--- a/finite-automata-designer/src/app/dfa/[id]/page.tsx
+++ b/finite-automata-designer/src/app/dfa/[id]/page.tsx
@@ -11,6 +11,7 @@ import Instructions from "@/app/components/editor/Instructions";
 import AutomataHeader from "@/app/components/editor/AutomataHeader";
 import ImportContainer from "@/app/components/editor/import/ImportContainer";
 import ExportContainer from "@/app/components/editor/export/ExportContainer";
+import ExportTextArea from "@/app/components/editor/export/ExportTextArea";
 
 
 function DFAPageContent() {
@@ -147,19 +148,9 @@ function DFAPageContent() {
                         Import as: <button id='svgImportBtn' type="button" className="cursor-pointer">SVG</button>
                         {' | '} <button id='latexImportBtn' type="button" className="cursor-pointer">LaTeX</button>
                     </div> */}
-                    <div id="exportOutputContainer" hidden className="text-center">
-                        <textarea 
-                        disabled
-                        tabIndex={-1}
-                        id="output"
-                        className="w-full h-24 mt-2 border border-gray-400 rounded text-black bg-white select-none" 
-                        placeholder="Export will appear here...">
-                        </textarea>
-                        <div className="flex gap-4 justify-center text-black">
-                            <button id='hideOutput' type="button" className="cursor-pointer text-center text-decoration underline">Hide Export Output</button>
-                            <button id='copyOutput' type="button" className="cursor-pointer text-center text-decoration underline">Copy Output</button>
-                        </div>
-                    </div>
+                    
+                    <ExportTextArea />
+
                     <div id="importInputContainer" hidden className="text-center">
                         <textarea 
                         tabIndex={-1}

--- a/finite-automata-designer/src/app/dfa/[id]/page.tsx
+++ b/finite-automata-designer/src/app/dfa/[id]/page.tsx
@@ -12,6 +12,7 @@ import AutomataHeader from "@/app/components/editor/AutomataHeader";
 import ImportContainer from "@/app/components/editor/import/ImportContainer";
 import ExportContainer from "@/app/components/editor/export/ExportContainer";
 import ExportTextArea from "@/app/components/editor/export/ExportTextArea";
+import InputString from "@/app/components/editor/InputString";
 
 
 function DFAPageContent() {
@@ -162,21 +163,8 @@ function DFAPageContent() {
                     <div className="flex flex-col gap-5">
                         <div id='inputDiv' className="flex flex-col self-center w-full max-w-md text-black">
                             {/* Textbox for inputting strings */}
-                            <label htmlFor="inputString" className="block mb-1 text-gray-700 text-xl font-bold">
-                                Input:
-                            </label>
-                            <input
-                                id="inputString"
-                                type="text"
-                                placeholder="Enter a string..."
-                                className="w-full px-4 py-2 border border-gray-400 rounded shadow-sm bg-white focus:outline-none focus:ring-2 focus:ring-blue-400"
-                                // Loose focus after you press enter
-                                onKeyDown={(e) => {
-                                    if (e.key === "Enter") {
-                                        e.currentTarget.blur();
-                                    }
-                                }}
-                            />
+                            <InputString />
+
                             <div className="min-h-[3rem]">
                                 {hasMultiCharAlphabet && (
                                     <div className="w-full rounded border border-red-300 bg-red-100 px-3 py-2">

--- a/finite-automata-designer/src/app/dfa/[id]/page.tsx
+++ b/finite-automata-designer/src/app/dfa/[id]/page.tsx
@@ -13,6 +13,7 @@ import ImportContainer from "@/app/components/editor/import/ImportContainer";
 import ExportContainer from "@/app/components/editor/export/ExportContainer";
 import ExportTextArea from "@/app/components/editor/export/ExportTextArea";
 import InputString from "@/app/components/editor/InputString";
+import AlphabetInput from "@/app/components/editor/alphabet/AlphabetInput";
 
 
 function DFAPageContent() {
@@ -179,20 +180,8 @@ function DFAPageContent() {
                             <label id="alphabetLabel" htmlFor="alphabet" className="block mb-1 text-gray-700 text-xl font-bold">
                                 Alphabet: {"{0,1}"}
                             </label>
-                            <input
-                                id="alphabet"
-                                type="text"
-                                placeholder="Enter an alphabet..."
-                                className="w-full px-4 py-2 border border-gray-400 rounded shadow-sm bg-white focus:outline-none focus:ring-2 focus:ring-blue-400"
-                                //onChange={(e) => setAlphabetDraft(e.target.value)}
-                                // Loose focus after you press enter
-                                onKeyDown={(e) => {
-                                    if (e.key === "Enter") {
-                                        e.currentTarget.blur();
-                                        //setAlphabetInput(alphabetDraft.trim());
-                                    }
-                                }}
-                            />
+                            
+                            <AlphabetInput />
                         </div>
                         <div className="flex flex-wrap self-center gap-5">
                             {/* Save button to save the DFA to the database only if the user is logged in */}

--- a/finite-automata-designer/src/app/dfa/[id]/page.tsx
+++ b/finite-automata-designer/src/app/dfa/[id]/page.tsx
@@ -8,13 +8,13 @@ import { saveAutomaton, updateAutomaton } from "@/lib/automata/mutations";
 import { FiniteAutomaton } from "@/lib/shared/types";
 import { getAutomaton } from "@/lib/automata/queries";
 import { SaveProjectModal } from "@/app/components/projects/SaveProjectModal";
+import { Instructions } from "@/app/components/editor/Instructions";
 
 
 function DFAPageContent() {
 
     const [hasMultiCharAlphabet, setHasMultiCharAlphabet] = useState(false);
     const [alphabetInput, setAlphabetInput] = useState("");
-    const [instructionsOpen, setInstructionsOpen] = useState(false);
     const [exportOpen, setExportOpen] = useState(false);
     const [importOpen, setImportOpen] = useState(false);
     const [isSaving, setIsSaving] = useState(false);
@@ -143,43 +143,9 @@ function DFAPageContent() {
                 <Link href="/" className="px-6 py-3 bg-gray-700 text-white rounded hover:bg-black transition">
                     ← Back
                 </Link>
-                <div className="mt-6 pr-4 w-full text-black">
-                    <button
-                        type="button"
-                        onClick={() => setInstructionsOpen(prev => !prev)}
-                        className="flex items-center gap-2 px-4 py-2 bg-gray-700 text-white rounded hover:bg-black transition"
-                    >
-                        Instructions
-                        <svg
-                            className={`h-4 w-4 transition-transform ${instructionsOpen ? "rotate-180" : ""}`}
-                            xmlns="http://www.w3.org/2000/svg"
-                            viewBox="0 0 20 20"
-                            fill="currentColor"
-                        >
-                            <path 
-                                fillRule="evenodd" 
-                                d="M5.23 7.21a.75.75 0 011.06.02L10 10.939l3.71-3.71a.75.75 0 111.06 1.06l-4.24 4.24a.75.75 0 01-1.06 0L5.25 8.27a.75.75 0 01-.02-1.06z" 
-                                clipRule="evenodd" 
-                            />
-                        </svg>
-                    </button>
-                    {instructionsOpen && (
-                        <ul className="list-disc text-left mt-3 ml-4 text-sm space-y-1">
-                            <li><p className="font-semibold inline">Add a state: </p>Double-click on the canvas</li>
-                            <li><p className="font-semibold inline">Define start state: </p>Shift + Click empty space on canvas + Drag your desired start state</li>
-                            <li><p className="font-semibold inline">Add an arrow between states: </p>Shift + Click initial state + Drag the mouse to your desired terminal state</li>
-                            <li><p className="font-semibold inline">Add a looped arrow on a state: </p>Shift + Click existing state</li>
-                            <li><p className="font-semibold inline">Curve arrows: </p>Click your desired arrow and drag in the direction you wish to curve it</li>
-                            <li><p className="font-semibold inline">Move anything: </p>Click + Drag it around</li>
-                            <li><p className="font-semibold inline">Delete anything: </p>Click it and press the delete key (not backspace)</li>
-                            <li><p className="font-semibold inline">Make accept state: </p>Double-click an existing state</li>
-                            <li><p className="font-semibold inline">Type onto arrow or state: </p>Click on desired state, then begin typing. Click again anywhere else to submit</li>
-                            <li><p className="font-semibold inline">Type numeric subscript: </p>Put an underscore before the number (ex: &quot;q_0&quot;)</li>
-                            <li><p className="font-semibold inline">Set alphabet: </p>Type a comma-separated list of all the characters you wish to define for your DFA. Press Enter to submit</li>
-                            <li><p className="font-semibold inline">Run DFA: </p>Type an input string containing only the characters from your alphabet. Press Enter to submit</li>
-                        </ul>
-                    )}
-                </div>
+                <Instructions 
+                    type={"DFA"}
+                />
             </div>
             {/* Canvas parent div*/}
             <div>

--- a/finite-automata-designer/src/app/dfa/[id]/page.tsx
+++ b/finite-automata-designer/src/app/dfa/[id]/page.tsx
@@ -4,8 +4,7 @@ import Script from 'next/script';
 import { useEffect, useState, Suspense, useRef } from "react";
 import { useParams } from "next/navigation";
 import { toggle_visiblity } from "../../../../public/scripts/canvasUtil/canvasUtil";
-import { saveAutomaton } from "@/lib/saveAutomaton";
-import { createClient } from "@/lib/supabase/client";
+import { saveAutomaton, updateAutomaton } from "@/lib/automata/mutations";
 import { FiniteAutomaton } from "@/lib/shared/types";
 import { getAutomaton } from "@/lib/automata/queries";
 
@@ -75,20 +74,27 @@ function DFAPageContent() {
         loadAutomaton();
     },[automatonId]);
 
-    async function handleSave(){
-        const supabase = createClient();
-        const { data: { user } } = await supabase.auth.getUser();
-
-        if(!user){
-            alert("Yout must be logged in to save.");
-            return;
-        }
+    async function handleSaveAsNew(name: string, description: string){
 
         const serialized = window.exportDFA();
         console.log(serialized);
 
         try{
-            await saveAutomaton(user.id, serialized);
+            await saveAutomaton(serialized, name, description);
+            alert("Automaton saved!");
+        }
+        catch (err) {
+            console.error(err);
+            alert("Save failed.");
+        }
+    }
+
+    async function handleSave(){
+        const serialized = window.exportDFA();
+        console.log(serialized);
+
+        try{
+            await updateAutomaton(serialized);
             alert("Automaton saved!");
         }
         catch (err) {
@@ -383,7 +389,7 @@ function DFAPageContent() {
                             {/* Save button to save the DFA to the database only if the user is logged in */}
                             <button
                                 type="button"
-                                onClick={handleSave}
+                                //onClick={handleSave}
                                 className="flex-none px-8 py-3 bg-gray-700 text-white rounded hover:bg-black transition"
                             >
                                 Save

--- a/finite-automata-designer/src/app/dfa/[id]/page.tsx
+++ b/finite-automata-designer/src/app/dfa/[id]/page.tsx
@@ -395,7 +395,7 @@ function DFAPageContent() {
                             {/* Save button to save the DFA to the database only if the user is logged in */}
                             <button
                                 type="button"
-                                //onClick={handleSave}
+                                onClick={handleSave}
                                 className="flex-none px-8 py-3 bg-gray-700 text-white rounded hover:bg-black transition"
                             >
                                 Save

--- a/finite-automata-designer/src/app/dfa/[id]/page.tsx
+++ b/finite-automata-designer/src/app/dfa/[id]/page.tsx
@@ -8,7 +8,7 @@ import { saveAutomaton, updateAutomaton } from "@/lib/automata/mutations";
 import { FiniteAutomaton } from "@/lib/shared/types";
 import { getAutomaton } from "@/lib/automata/queries";
 import { SaveProjectModal } from "@/app/components/projects/SaveProjectModal";
-import { Instructions } from "@/app/components/editor/Instructions";
+import Instructions from "@/app/components/editor/Instructions";
 
 
 function DFAPageContent() {

--- a/finite-automata-designer/src/app/dfa/[id]/page.tsx
+++ b/finite-automata-designer/src/app/dfa/[id]/page.tsx
@@ -10,6 +10,7 @@ import { getAutomaton } from "@/lib/automata/queries";
 import { SaveProjectModal } from "@/app/components/projects/SaveProjectModal";
 import Instructions from "@/app/components/editor/Instructions";
 import AutomataHeader from "@/app/components/editor/AutomataHeader";
+import ImportContainer from "@/app/components/editor/ImportContainer";
 
 
 function DFAPageContent() {
@@ -17,7 +18,6 @@ function DFAPageContent() {
     const [hasMultiCharAlphabet, setHasMultiCharAlphabet] = useState(false);
     const [alphabetInput, setAlphabetInput] = useState("");
     const [exportOpen, setExportOpen] = useState(false);
-    const [importOpen, setImportOpen] = useState(false);
     const [isSaving, setIsSaving] = useState(false);
     const [name, setName] = useState<string | null>(null);
     const [description, setDescription] = useState<string | null>(null);
@@ -31,7 +31,6 @@ function DFAPageContent() {
     // onReady on the <Script> tag drains this once the script is ready.
     const pendingAutomaton = useRef<unknown>(null);
     const exportMenuRef = useRef<HTMLDivElement>(null);
-    const importMenuRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
 
@@ -199,75 +198,7 @@ function DFAPageContent() {
                         </div>
                     </div>
                     {/* Importing dropdowns container*/}
-                    <div className="flex gap-2 mt-2">
-                        <p className="text-lg">Import as: </p> 
-                        <div className="flex gap-2">
-                            {/* Importing options parent selector*/}
-                            <div className="relative inline-block text-left">
-                                <button
-                                    id="importMenuBtn"
-                                    type="button"
-                                    onClick={() => {
-                                        if (importMenuRef.current) toggle_visiblity(importMenuRef.current);
-                                        setImportOpen(prev => !prev);
-                                    }}
-                                    className="flex justify-center gap-x-1.5 rounded-md bg-gray-700 text-white px-2 py-1 text-md hover:bg-black transition"
-                                >
-                                    Import Options
-                                    <svg
-                                        className={`-mr-1 h-5 w-5 text-gray-400 h-4 w-4 transition-transform ${importOpen ? "rotate-180" : ""}`}
-                                        xmlns="http://www.w3.org/2000/svg"
-                                        viewBox="0 0 20 20"
-                                        fill="currentColor"
-                                        aria-hidden="true"
-                                    >
-                                        <path
-                                            fillRule="evenodd"
-                                            d="M5.23 7.21a.75.75 0 011.06.02L10 10.939l3.71-3.71a.75.75 0 111.06 1.06l-4.24 4.24a.75.75 0 01-1.06 0L5.25 8.27a.75.75 0 01-.02-1.06z"
-                                            clipRule="evenodd"
-                                        />
-                                    </svg>
-                                </button>
-                                {/* Import Menu options (SVG and LaTeX)*/}
-                                <div
-                                    ref={importMenuRef}
-                                    id="importMenu"
-                                    hidden
-                                    className="absolute mt-2 w-40 rounded-md bg-gray-700 shadow-lg z-20"
-                                >
-                                    <button
-                                    id="svgImportBtn"
-                                    type="button"
-                                    onClick={() => {
-                                        if (importMenuRef.current) toggle_visiblity(importMenuRef.current);
-                                        setImportOpen(false);
-                                    }}
-                                    className="block w-full px-4 py-2 text-left text-white hover:bg-gray-600"
-                                    >
-                                    Import as SVG
-                                    </button>
-                                    <button
-                                    id="latexImportBtn"
-                                    type="button"
-                                    onClick={() => {
-                                        if (importMenuRef.current) toggle_visiblity(importMenuRef.current);
-                                        setImportOpen(false);
-                                    }}
-                                    className="block w-full px-4 py-2 text-left text-white hover:bg-gray-600"
-                                    >
-                                    Import as LaTeX
-                                    </button>
-                                </div>
-                            </div>
-                            <button 
-                            id="confirmImport"
-                            className="flex justify-center gap-x-1.5 rounded-md bg-gray-700 text-white px-2 py-1 text-md hover:bg-black transition" 
-                            hidden
-                            >
-                                Draw Import
-                            </button>
-                        </div>
-                    </div>
+                    <ImportContainer />
                     
                     {/*Leave for now in case we turn back the UI for importing and exporting*/}
 

--- a/finite-automata-designer/src/app/dfa/[id]/page.tsx
+++ b/finite-automata-designer/src/app/dfa/[id]/page.tsx
@@ -394,6 +394,14 @@ function DFAPageContent() {
                             >
                                 Save
                             </button>
+
+                            <button
+                                type="button"
+                                onClick={() => setIsSaving(true)}
+                                className="flex-none px-8 py-3 bg-gray-700 text-white rounded hover:bg-black transition"
+                            >
+                                Save As New Project
+                            </button>
                     
                             {/* Run button to run the DFA with the given input string */}
                             <button

--- a/finite-automata-designer/src/app/dfa/[id]/page.tsx
+++ b/finite-automata-designer/src/app/dfa/[id]/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import Link from "next/link";
+
 import Script from 'next/script';
 import { useEffect, useState, Suspense, useRef } from "react";
 import { useParams, useRouter } from "next/navigation";
@@ -19,6 +19,7 @@ import RunButton from "@/app/components/editor/RunButton";
 import ProjectsButton from "@/app/components/editor/ProjectsButton";
 import ClearCanvasButton from "@/app/components/editor/ClearCanvasButton";
 import ImportTextArea from "@/app/components/editor/import/ImportTextArea";
+import BackButton from "@/app/components/editor/BackButton";
 
 
 function DFAPageContent() {
@@ -123,18 +124,19 @@ function DFAPageContent() {
             title={!name ? "Deterministic Finite Automata" : ("DFA: " + name)}
             description={description}
         />
+
         <div
             className="flex w-full"
         >
             {/* Back Button + Instructions parent div*/}
             <div className="flex-1 flex flex-col items-start h-13 pl-5" >
                 {/* Back Button to return to Home Page */}
-                <Link href="/" className="px-6 py-3 bg-gray-700 text-white rounded hover:bg-black transition">
-                    ← Back
-                </Link>
+                <BackButton />
+
                 <Instructions 
                     type={"DFA"}
                 />
+                
             </div>
             {/* Canvas parent div*/}
             <div>

--- a/finite-automata-designer/src/app/dfa/[id]/page.tsx
+++ b/finite-automata-designer/src/app/dfa/[id]/page.tsx
@@ -9,8 +9,8 @@ import { getAutomaton } from "@/lib/automata/queries";
 import { SaveProjectModal } from "@/app/components/projects/SaveProjectModal";
 import Instructions from "@/app/components/editor/Instructions";
 import AutomataHeader from "@/app/components/editor/AutomataHeader";
-import ImportContainer from "@/app/components/editor/ImportContainer";
-import ExportContainer from "@/app/components/editor/ExportContainer";
+import ImportContainer from "@/app/components/editor/import/ImportContainer";
+import ExportContainer from "@/app/components/editor/export/ExportContainer";
 
 
 function DFAPageContent() {

--- a/finite-automata-designer/src/app/dfa/[id]/page.tsx
+++ b/finite-automata-designer/src/app/dfa/[id]/page.tsx
@@ -20,6 +20,7 @@ import ProjectsButton from "@/app/components/editor/ProjectsButton";
 import ClearCanvasButton from "@/app/components/editor/ClearCanvasButton";
 import ImportTextArea from "@/app/components/editor/import/ImportTextArea";
 import BackButton from "@/app/components/editor/BackButton";
+import SaveActions from '@/app/components/editor/SaveActions';
 
 
 function DFAPageContent() {
@@ -136,7 +137,7 @@ function DFAPageContent() {
                 <Instructions 
                     type={"DFA"}
                 />
-                
+
             </div>
             {/* Canvas parent div*/}
             <div>
@@ -184,7 +185,7 @@ function DFAPageContent() {
                         </div>
                         <div className="flex flex-wrap self-center gap-5">
                             {/* Save button to save the DFA to the database only if the user is logged in */}
-                            <button
+                            {/* <button
                                 type="button"
                                 onClick={handleSave}
                                 className="flex-none px-8 py-3 bg-gray-700 text-white rounded hover:bg-black transition"
@@ -198,7 +199,12 @@ function DFAPageContent() {
                                 className="flex-none px-8 py-3 bg-gray-700 text-white rounded hover:bg-black transition"
                             >
                                 Save As New Project
-                            </button>
+                            </button> */}
+
+                            <SaveActions
+                                onSave={handleSave}
+                                onSaveAs={() => setIsSaving(true)}
+                            />
                     
                             {/* Run button to run the DFA with the given input string */}
                             <RunButton 

--- a/finite-automata-designer/src/app/dfa/[id]/page.tsx
+++ b/finite-automata-designer/src/app/dfa/[id]/page.tsx
@@ -1,0 +1,463 @@
+'use client';
+import Link from "next/link";
+import Script from 'next/script';
+import { useEffect, useState, Suspense, useRef } from "react";
+import { useParams } from "next/navigation";
+import { toggle_visiblity } from "../../../../public/scripts/canvasUtil/canvasUtil";
+import { saveAutomaton } from "@/lib/saveAutomaton";
+import { createClient } from "@/lib/supabase/client";
+
+
+function DFAPageContent() {
+
+    const [hasMultiCharAlphabet, setHasMultiCharAlphabet] = useState(false);
+    const [alphabetInput, setAlphabetInput] = useState("");
+    const [instructionsOpen, setInstructionsOpen] = useState(false);
+    const [exportOpen, setExportOpen] = useState(false);
+    const [importOpen, setImportOpen] = useState(false);
+    const [isSaving, setIsSaving] = useState(false);
+
+    const params = useParams();
+
+    const automatonId = params?.id as string;
+
+    // Holds automaton data fetched before the canvas script has finished loading.
+    // onReady on the <Script> tag drains this once the script is ready.
+    const pendingAutomaton = useRef<unknown>(null);
+    const exportMenuRef = useRef<HTMLDivElement>(null);
+    const importMenuRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+
+        // This will listen for alphabet updates from the canvas script
+        const handler = (event: Event) => {
+            const customEvent = event as CustomEvent<{alphabet: string[]}>;
+            const symbols = customEvent.detail.alphabet;
+
+            const alphabetString = symbols.join(',');
+            setAlphabetInput(alphabetString);
+
+            const hasMulti = symbols.some(symbol => symbol.length > 1);
+            setHasMultiCharAlphabet(hasMulti);
+        }
+
+        window.addEventListener("dfaAlphabetUpdated", handler);
+
+        return () => {
+            window.removeEventListener("dfaAlphabetUpdated", handler);
+        }
+
+    }, [alphabetInput]);
+
+    useEffect(() => {
+        // Clear stale pending data whenever the target id changes
+        pendingAutomaton.current = null;
+
+        async function loadAutomaton(){
+            if(!automatonId){
+                return;
+            }
+
+            const supabase = createClient();
+
+            const { data, error } = await supabase
+                .from("finite_automata")
+                .select("automaton")
+                .eq("id",automatonId)
+                .single();
+
+            if(error){
+                console.error("Error loading automaton: ", error);
+                return;
+            }
+
+            if(!data){
+                console.log("No data");
+                return;
+            }
+
+            if (typeof window.loadDFAIntoCanvas === 'function') {
+                // Canvas script is already loaded — call directly.
+                window.loadDFAIntoCanvas(data.automaton);
+            } else {
+                // Canvas script hasn't finished loading yet (production race).
+                // Store the data so the onReady callback can deliver it once ready.
+                pendingAutomaton.current = data.automaton;
+            }
+        }
+        loadAutomaton();
+    },[automatonId]);
+
+    async function handleSave(){
+        const supabase = createClient();
+        const { data: { user } } = await supabase.auth.getUser();
+
+        if(!user){
+            alert("Yout must be logged in to save.");
+            return;
+        }
+
+        const serialized = window.exportDFA();
+        console.log(serialized);
+
+        try{
+            await saveAutomaton(user.id, serialized);
+            alert("Automaton saved!");
+        }
+        catch (err) {
+            console.error(err);
+            alert("Save failed.");
+        }
+    }
+
+    return (
+      <main className="min-h-screen bg-blue-100 flex flex-col items-center">
+        {/* DFA title at the top */}
+        <h1 className="text-5xl font-bold text-center my-2 text-black ">
+            <span className="drop-shadow-[0_0_1px_rgba(0,0,0,0.7)]">
+                Deterministic Finite Automata
+            </span>
+            <span className="h-8 bg-gradient-to-b from-white/30 via-white/10 to-transparent opacity-20 rounded pointer-events-none"></span>
+        </h1>
+        <div
+            className="flex w-full"
+        >
+            {/* Back Button + Instructions parent div*/}
+            <div className="flex-1 flex flex-col items-start h-13 pl-5" >
+                {/* Back Button to return to Home Page */}
+                <Link href="/" className="px-6 py-3 bg-gray-700 text-white rounded hover:bg-black transition">
+                    ← Back
+                </Link>
+                <div className="mt-6 pr-4 w-full text-black">
+                    <button
+                        type="button"
+                        onClick={() => setInstructionsOpen(prev => !prev)}
+                        className="flex items-center gap-2 px-4 py-2 bg-gray-700 text-white rounded hover:bg-black transition"
+                    >
+                        Instructions
+                        <svg
+                            className={`h-4 w-4 transition-transform ${instructionsOpen ? "rotate-180" : ""}`}
+                            xmlns="http://www.w3.org/2000/svg"
+                            viewBox="0 0 20 20"
+                            fill="currentColor"
+                        >
+                            <path 
+                                fillRule="evenodd" 
+                                d="M5.23 7.21a.75.75 0 011.06.02L10 10.939l3.71-3.71a.75.75 0 111.06 1.06l-4.24 4.24a.75.75 0 01-1.06 0L5.25 8.27a.75.75 0 01-.02-1.06z" 
+                                clipRule="evenodd" 
+                            />
+                        </svg>
+                    </button>
+                    {instructionsOpen && (
+                        <ul className="list-disc text-left mt-3 ml-4 text-sm space-y-1">
+                            <li><p className="font-semibold inline">Add a state: </p>Double-click on the canvas</li>
+                            <li><p className="font-semibold inline">Define start state: </p>Shift + Click empty space on canvas + Drag your desired start state</li>
+                            <li><p className="font-semibold inline">Add an arrow between states: </p>Shift + Click initial state + Drag the mouse to your desired terminal state</li>
+                            <li><p className="font-semibold inline">Add a looped arrow on a state: </p>Shift + Click existing state</li>
+                            <li><p className="font-semibold inline">Curve arrows: </p>Click your desired arrow and drag in the direction you wish to curve it</li>
+                            <li><p className="font-semibold inline">Move anything: </p>Click + Drag it around</li>
+                            <li><p className="font-semibold inline">Delete anything: </p>Click it and press the delete key (not backspace)</li>
+                            <li><p className="font-semibold inline">Make accept state: </p>Double-click an existing state</li>
+                            <li><p className="font-semibold inline">Type onto arrow or state: </p>Click on desired state, then begin typing. Click again anywhere else to submit</li>
+                            <li><p className="font-semibold inline">Type numeric subscript: </p>Put an underscore before the number (ex: &quot;q_0&quot;)</li>
+                            <li><p className="font-semibold inline">Set alphabet: </p>Type a comma-separated list of all the characters you wish to define for your DFA. Press Enter to submit</li>
+                            <li><p className="font-semibold inline">Run DFA: </p>Type an input string containing only the characters from your alphabet. Press Enter to submit</li>
+                        </ul>
+                    )}
+                </div>
+            </div>
+            {/* Canvas parent div*/}
+            <div>
+                <div id="canvasDiv" className="flex flex-col text-black">
+                    {/* Canvas for drawing FSM */}
+                    <canvas id="DFACanvas" width={800} height={600} className="rounded-lg border border-gray-400"></canvas>
+                    {/* Exporting dropdowns container*/}
+                    <div className="flex gap-2">
+                        <p className="text-lg mt-5">Export as: </p> 
+                        <div className="relative inline-block text-left mt-5">
+                            {/* Exporting options parent selector*/}
+                            <button
+                                id="exportMenuBtn"
+                                type="button"
+                                onClick={() => {
+                                    if (exportMenuRef.current) toggle_visiblity(exportMenuRef.current);
+                                    setExportOpen(prev => !prev);
+                                }}
+                                className="flex justify-center gap-x-1.5 rounded-md bg-gray-700 text-white px-2 py-1 text-md hover:bg-black transition"
+                            >
+                                Export Options
+                                <svg
+                                    className={`-mr-1 h-5 w-5 text-gray-400 h-4 w-4 transition-transform ${exportOpen ? "rotate-180" : ""}`}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    viewBox="0 0 20 20"
+                                    fill="currentColor"
+                                    aria-hidden="true"
+                                >
+                                    <path
+                                        fillRule="evenodd"
+                                        d="M5.23 7.21a.75.75 0 011.06.02L10 10.939l3.71-3.71a.75.75 0 111.06 1.06l-4.24 4.24a.75.75 0 01-1.06 0L5.25 8.27a.75.75 0 01-.02-1.06z"
+                                        clipRule="evenodd"
+                                    />
+                                </svg>
+                            </button>
+                            
+                            {/* Export Menu options (SVG and LaTeX)*/}
+                            <div
+                                ref={exportMenuRef}
+                                id="exportMenu"
+                                hidden
+                                className="absolute mt-2 w-40 rounded-md bg-gray-700 shadow-lg z-20"
+                            >
+                                <button
+                                    id="svgExportBtn"
+                                    type="button"
+                                    onClick={() => {
+                                        if (exportMenuRef.current) toggle_visiblity(exportMenuRef.current);
+                                        setExportOpen(false);
+                                    }}
+                                    className="block w-full px-4 py-2 text-left text-white hover:bg-gray-600"
+                                >
+                                    SVG
+                                </button>
+                                <button
+                                    id="latexExportBtn"
+                                    type="button"
+                                    onClick={() => {
+                                        if (exportMenuRef.current) toggle_visiblity(exportMenuRef.current);
+                                        setExportOpen(false);
+                                    }}
+                                    className="block w-full px-4 py-2 text-left text-white hover:bg-gray-600"
+                                >
+                                    LaTeX
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                    {/* Importing dropdowns container*/}
+                    <div className="flex gap-2 mt-2">
+                        <p className="text-lg">Import as: </p> 
+                        <div className="flex gap-2">
+                            {/* Importing options parent selector*/}
+                            <div className="relative inline-block text-left">
+                                <button
+                                    id="importMenuBtn"
+                                    type="button"
+                                    onClick={() => {
+                                        if (importMenuRef.current) toggle_visiblity(importMenuRef.current);
+                                        setImportOpen(prev => !prev);
+                                    }}
+                                    className="flex justify-center gap-x-1.5 rounded-md bg-gray-700 text-white px-2 py-1 text-md hover:bg-black transition"
+                                >
+                                    Import Options
+                                    <svg
+                                        className={`-mr-1 h-5 w-5 text-gray-400 h-4 w-4 transition-transform ${importOpen ? "rotate-180" : ""}`}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                        viewBox="0 0 20 20"
+                                        fill="currentColor"
+                                        aria-hidden="true"
+                                    >
+                                        <path
+                                            fillRule="evenodd"
+                                            d="M5.23 7.21a.75.75 0 011.06.02L10 10.939l3.71-3.71a.75.75 0 111.06 1.06l-4.24 4.24a.75.75 0 01-1.06 0L5.25 8.27a.75.75 0 01-.02-1.06z"
+                                            clipRule="evenodd"
+                                        />
+                                    </svg>
+                                </button>
+                                {/* Import Menu options (SVG and LaTeX)*/}
+                                <div
+                                    ref={importMenuRef}
+                                    id="importMenu"
+                                    hidden
+                                    className="absolute mt-2 w-40 rounded-md bg-gray-700 shadow-lg z-20"
+                                >
+                                    <button
+                                    id="svgImportBtn"
+                                    type="button"
+                                    onClick={() => {
+                                        if (importMenuRef.current) toggle_visiblity(importMenuRef.current);
+                                        setImportOpen(false);
+                                    }}
+                                    className="block w-full px-4 py-2 text-left text-white hover:bg-gray-600"
+                                    >
+                                    Import as SVG
+                                    </button>
+                                    <button
+                                    id="latexImportBtn"
+                                    type="button"
+                                    onClick={() => {
+                                        if (importMenuRef.current) toggle_visiblity(importMenuRef.current);
+                                        setImportOpen(false);
+                                    }}
+                                    className="block w-full px-4 py-2 text-left text-white hover:bg-gray-600"
+                                    >
+                                    Import as LaTeX
+                                    </button>
+                                </div>
+                            </div>
+                            <button 
+                            id="confirmImport"
+                            className="flex justify-center gap-x-1.5 rounded-md bg-gray-700 text-white px-2 py-1 text-md hover:bg-black transition" 
+                            hidden
+                            >
+                                Draw Import
+                            </button>
+                        </div>
+                    </div>
+                    
+                    {/*Leave for now in case we turn back the UI for importing and exporting*/}
+
+                    {/* <div className="text-center text-black mt-2">
+                        Export as: <button id='svgExportBtn' type="button" className="cursor-pointer">SVG</button>
+                        {' | '} <button id='latexExportBtn' type="button" className="cursor-pointer">LaTeX</button>
+                        <br />
+                        Import as: <button id='svgImportBtn' type="button" className="cursor-pointer">SVG</button>
+                        {' | '} <button id='latexImportBtn' type="button" className="cursor-pointer">LaTeX</button>
+                    </div> */}
+                    <div id="exportOutputContainer" hidden className="text-center">
+                        <textarea 
+                        disabled
+                        tabIndex={-1}
+                        id="output"
+                        className="w-full h-24 mt-2 border border-gray-400 rounded text-black bg-white select-none" 
+                        placeholder="Export will appear here...">
+                        </textarea>
+                        <div className="flex gap-4 justify-center text-black">
+                            <button id='hideOutput' type="button" className="cursor-pointer text-center text-decoration underline">Hide Export Output</button>
+                            <button id='copyOutput' type="button" className="cursor-pointer text-center text-decoration underline">Copy Output</button>
+                        </div>
+                    </div>
+                    <div id="importInputContainer" hidden className="text-center">
+                        <textarea 
+                        tabIndex={-1}
+                        id="input"
+                        className="w-full h-24 mt-2 border border-gray-400 rounded text-black bg-white select-none" 
+                        placeholder="Enter the input data that you exported EXCLUSIVELY from this FA designer goes here...">
+                        </textarea>
+                        <div className="flex gap-4 justify-center text-black">
+                            <button id='hideInput' type="button" className="cursor-pointer text-center text-decoration underline">Hide Input</button>
+                            <button id='clearInput' type="button" className="cursor-pointer text-center text-decoration underline">Clear Input</button>
+                        </div>
+                    </div>
+                
+                </div>
+            </div>
+                
+            {/* Right hand parent div*/}
+            <div className="flex-1">
+                <div className="flex flex-col gap-3 h-13 justify-start-safe pl-5">
+                    <div className="flex flex-col gap-5">
+                        <div id='inputDiv' className="flex flex-col self-center w-full max-w-md text-black">
+                            {/* Textbox for inputting strings */}
+                            <label htmlFor="inputString" className="block mb-1 text-gray-700 text-xl font-bold">
+                                Input:
+                            </label>
+                            <input
+                                id="inputString"
+                                type="text"
+                                placeholder="Enter a string..."
+                                className="w-full px-4 py-2 border border-gray-400 rounded shadow-sm bg-white focus:outline-none focus:ring-2 focus:ring-blue-400"
+                                // Loose focus after you press enter
+                                onKeyDown={(e) => {
+                                    if (e.key === "Enter") {
+                                        e.currentTarget.blur();
+                                    }
+                                }}
+                            />
+                            <div className="min-h-[3rem]">
+                                {hasMultiCharAlphabet && (
+                                    <div className="w-full rounded border border-red-300 bg-red-100 px-3 py-2">
+                                        <p className="text-sm text-red-700 font-semibold">
+                                            Multi-character element detected in alphabet. Please separate elements
+                                            in your input string with commas or spaces.
+                                        </p>
+                                    </div>
+                                )}
+                            </div>
+                            {/* Textbox for inputting the alphabet */}
+                            <label id="alphabetLabel" htmlFor="alphabet" className="block mb-1 text-gray-700 text-xl font-bold">
+                                Alphabet: {"{0,1}"}
+                            </label>
+                            <input
+                                id="alphabet"
+                                type="text"
+                                placeholder="Enter an alphabet..."
+                                className="w-full px-4 py-2 border border-gray-400 rounded shadow-sm bg-white focus:outline-none focus:ring-2 focus:ring-blue-400"
+                                //onChange={(e) => setAlphabetDraft(e.target.value)}
+                                // Loose focus after you press enter
+                                onKeyDown={(e) => {
+                                    if (e.key === "Enter") {
+                                        e.currentTarget.blur();
+                                        //setAlphabetInput(alphabetDraft.trim());
+                                    }
+                                }}
+                            />
+                        </div>
+                        <div className="flex flex-wrap self-center gap-5">
+                            {/* Save button to save the DFA to the database only if the user is logged in */}
+                            <button
+                                type="button"
+                                onClick={handleSave}
+                                className="flex-none px-8 py-3 bg-gray-700 text-white rounded hover:bg-black transition"
+                            >
+                                Save
+                            </button>
+                    
+                            {/* Run button to run the DFA with the given input string */}
+                            <button
+                                id="dfaRunBtn"
+                                type="button"
+                                className="flex-none px-8 py-3 bg-gray-700 text-white rounded hover:bg-black transition"
+                            >
+                                Run
+                            </button>
+                            {/* My Projects button to open the projects page that will list all of the users project when logged in */}
+                            <Link
+                                href="/projects"
+                                className="flex-none px-8 py-3 bg-gray-700 text-white rounded hover:bg-black transition"
+                                >
+                                My Projects
+                            </Link>
+                        </div>
+                    </div>
+                    {/* Clear Canvas parent container */}
+                    <div>
+                        <div className="mt-4 flex justify-center">
+                            <button
+                                id="clearCanvas"
+                                type="button"
+                                className="bg-gray-700 text-white px-6 py-3 rounded hover:bg-gray-500 transition">
+                                Clear Canvas
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <Script
+            src="/scripts/dfa/dfaCanvas.js"
+            type="module"
+            strategy="afterInteractive"
+            crossOrigin="anonymous"
+            onReady={() => {
+                // Fires when the script first loads AND after every subsequent
+                // component mount where the script is already cached.
+                // Delivers any automaton data that arrived before the script was ready.
+                if (pendingAutomaton.current !== null) {
+                    window.loadDFAIntoCanvas(pendingAutomaton.current);
+                    pendingAutomaton.current = null;
+                }
+            }}
+        />
+      </main>
+
+    );
+}
+
+export default function DFAPage() {
+    return (
+        <Suspense>
+            <DFAPageContent />
+        </Suspense>
+    );
+}

--- a/finite-automata-designer/src/app/dfa/[id]/page.tsx
+++ b/finite-automata-designer/src/app/dfa/[id]/page.tsx
@@ -18,6 +18,7 @@ import AlphabetLabel from "@/app/components/editor/alphabet/AlphabetLabel";
 import RunButton from "@/app/components/editor/RunButton";
 import ProjectsButton from "@/app/components/editor/ProjectsButton";
 import ClearCanvasButton from "@/app/components/editor/ClearCanvasButton";
+import ImportTextArea from "@/app/components/editor/import/ImportTextArea";
 
 
 function DFAPageContent() {
@@ -140,8 +141,10 @@ function DFAPageContent() {
                 <div id="canvasDiv" className="flex flex-col text-black">
                     {/* Canvas for drawing FSM */}
                     <canvas id="DFACanvas" width={800} height={600} className="rounded-lg border border-gray-400"></canvas>
+
                     {/* Exporting dropdowns container*/}
                     <ExportContainer />
+
                     {/* Importing dropdowns container*/}
                     <ImportContainer />
                     
@@ -157,8 +160,8 @@ function DFAPageContent() {
                     
                     <ExportTextArea />
 
-                    
-                
+                    <ImportTextArea />
+
                 </div>
             </div>
                 
@@ -175,6 +178,7 @@ function DFAPageContent() {
                             />
                             
                             <AlphabetInput />
+
                         </div>
                         <div className="flex flex-wrap self-center gap-5">
                             {/* Save button to save the DFA to the database only if the user is logged in */}

--- a/finite-automata-designer/src/app/dfa/[id]/page.tsx
+++ b/finite-automata-designer/src/app/dfa/[id]/page.tsx
@@ -185,22 +185,6 @@ function DFAPageContent() {
                         </div>
                         <div className="flex flex-wrap self-center gap-5">
                             {/* Save button to save the DFA to the database only if the user is logged in */}
-                            {/* <button
-                                type="button"
-                                onClick={handleSave}
-                                className="flex-none px-8 py-3 bg-gray-700 text-white rounded hover:bg-black transition"
-                            >
-                                Save
-                            </button>
-
-                            <button
-                                type="button"
-                                onClick={() => setIsSaving(true)}
-                                className="flex-none px-8 py-3 bg-gray-700 text-white rounded hover:bg-black transition"
-                            >
-                                Save As New Project
-                            </button> */}
-
                             <SaveActions
                                 onSave={handleSave}
                                 onSaveAs={() => setIsSaving(true)}

--- a/finite-automata-designer/src/app/dfa/[id]/page.tsx
+++ b/finite-automata-designer/src/app/dfa/[id]/page.tsx
@@ -6,6 +6,8 @@ import { useParams } from "next/navigation";
 import { toggle_visiblity } from "../../../../public/scripts/canvasUtil/canvasUtil";
 import { saveAutomaton } from "@/lib/saveAutomaton";
 import { createClient } from "@/lib/supabase/client";
+import { FiniteAutomaton } from "@/lib/shared/types";
+import { getAutomaton } from "@/lib/automata/queries";
 
 
 function DFAPageContent() {
@@ -58,33 +60,18 @@ function DFAPageContent() {
                 return;
             }
 
-            const supabase = createClient();
-
-            const { data, error } = await supabase
-                .from("finite_automata")
-                .select("automaton")
-                .eq("id",automatonId)
-                .single();
-
-            if(error){
-                console.error("Error loading automaton: ", error);
-                return;
-            }
-
-            if(!data){
-                console.log("No data");
-                return;
-            }
+            const finiteAutomatonData: FiniteAutomaton = await getAutomaton(automatonId);
 
             if (typeof window.loadDFAIntoCanvas === 'function') {
                 // Canvas script is already loaded — call directly.
-                window.loadDFAIntoCanvas(data.automaton);
+                window.loadDFAIntoCanvas(finiteAutomatonData.automaton);
             } else {
                 // Canvas script hasn't finished loading yet (production race).
                 // Store the data so the onReady callback can deliver it once ready.
-                pendingAutomaton.current = data.automaton;
+                pendingAutomaton.current = finiteAutomatonData.automaton;
             }
         }
+
         loadAutomaton();
     },[automatonId]);
 

--- a/finite-automata-designer/src/app/dfa/[id]/page.tsx
+++ b/finite-automata-designer/src/app/dfa/[id]/page.tsx
@@ -3,7 +3,6 @@ import Link from "next/link";
 import Script from 'next/script';
 import { useEffect, useState, Suspense, useRef } from "react";
 import { useParams, useRouter } from "next/navigation";
-import { toggle_visiblity } from "../../../../public/scripts/canvasUtil/canvasUtil";
 import { saveAutomaton, updateAutomaton } from "@/lib/automata/mutations";
 import { FiniteAutomaton } from "@/lib/shared/types";
 import { getAutomaton } from "@/lib/automata/queries";
@@ -11,13 +10,13 @@ import { SaveProjectModal } from "@/app/components/projects/SaveProjectModal";
 import Instructions from "@/app/components/editor/Instructions";
 import AutomataHeader from "@/app/components/editor/AutomataHeader";
 import ImportContainer from "@/app/components/editor/ImportContainer";
+import ExportContainer from "@/app/components/editor/ExportContainer";
 
 
 function DFAPageContent() {
 
     const [hasMultiCharAlphabet, setHasMultiCharAlphabet] = useState(false);
     const [alphabetInput, setAlphabetInput] = useState("");
-    const [exportOpen, setExportOpen] = useState(false);
     const [isSaving, setIsSaving] = useState(false);
     const [name, setName] = useState<string | null>(null);
     const [description, setDescription] = useState<string | null>(null);
@@ -30,7 +29,6 @@ function DFAPageContent() {
     // Holds automaton data fetched before the canvas script has finished loading.
     // onReady on the <Script> tag drains this once the script is ready.
     const pendingAutomaton = useRef<unknown>(null);
-    const exportMenuRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
 
@@ -136,67 +134,7 @@ function DFAPageContent() {
                     {/* Canvas for drawing FSM */}
                     <canvas id="DFACanvas" width={800} height={600} className="rounded-lg border border-gray-400"></canvas>
                     {/* Exporting dropdowns container*/}
-                    <div className="flex gap-2">
-                        <p className="text-lg mt-5">Export as: </p> 
-                        <div className="relative inline-block text-left mt-5">
-                            {/* Exporting options parent selector*/}
-                            <button
-                                id="exportMenuBtn"
-                                type="button"
-                                onClick={() => {
-                                    if (exportMenuRef.current) toggle_visiblity(exportMenuRef.current);
-                                    setExportOpen(prev => !prev);
-                                }}
-                                className="flex justify-center gap-x-1.5 rounded-md bg-gray-700 text-white px-2 py-1 text-md hover:bg-black transition"
-                            >
-                                Export Options
-                                <svg
-                                    className={`-mr-1 h-5 w-5 text-gray-400 h-4 w-4 transition-transform ${exportOpen ? "rotate-180" : ""}`}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                    viewBox="0 0 20 20"
-                                    fill="currentColor"
-                                    aria-hidden="true"
-                                >
-                                    <path
-                                        fillRule="evenodd"
-                                        d="M5.23 7.21a.75.75 0 011.06.02L10 10.939l3.71-3.71a.75.75 0 111.06 1.06l-4.24 4.24a.75.75 0 01-1.06 0L5.25 8.27a.75.75 0 01-.02-1.06z"
-                                        clipRule="evenodd"
-                                    />
-                                </svg>
-                            </button>
-                            
-                            {/* Export Menu options (SVG and LaTeX)*/}
-                            <div
-                                ref={exportMenuRef}
-                                id="exportMenu"
-                                hidden
-                                className="absolute mt-2 w-40 rounded-md bg-gray-700 shadow-lg z-20"
-                            >
-                                <button
-                                    id="svgExportBtn"
-                                    type="button"
-                                    onClick={() => {
-                                        if (exportMenuRef.current) toggle_visiblity(exportMenuRef.current);
-                                        setExportOpen(false);
-                                    }}
-                                    className="block w-full px-4 py-2 text-left text-white hover:bg-gray-600"
-                                >
-                                    SVG
-                                </button>
-                                <button
-                                    id="latexExportBtn"
-                                    type="button"
-                                    onClick={() => {
-                                        if (exportMenuRef.current) toggle_visiblity(exportMenuRef.current);
-                                        setExportOpen(false);
-                                    }}
-                                    className="block w-full px-4 py-2 text-left text-white hover:bg-gray-600"
-                                >
-                                    LaTeX
-                                </button>
-                            </div>
-                        </div>
-                    </div>
+                    <ExportContainer />
                     {/* Importing dropdowns container*/}
                     <ImportContainer />
                     

--- a/finite-automata-designer/src/app/dfa/[id]/page.tsx
+++ b/finite-automata-designer/src/app/dfa/[id]/page.tsx
@@ -17,6 +17,7 @@ import AlphabetInput from "@/app/components/editor/alphabet/AlphabetInput";
 import AlphabetLabel from "@/app/components/editor/alphabet/AlphabetLabel";
 import RunButton from "@/app/components/editor/RunButton";
 import ProjectsButton from "@/app/components/editor/ProjectsButton";
+import ClearCanvasButton from "@/app/components/editor/ClearCanvasButton";
 
 
 function DFAPageContent() {
@@ -200,19 +201,12 @@ function DFAPageContent() {
 
                             {/* My Projects button to open the projects page that will list all of the users project when logged in */}
                             <ProjectsButton />
-                            
+
                         </div>
                     </div>
                     {/* Clear Canvas parent container */}
                     <div>
-                        <div className="mt-4 flex justify-center">
-                            <button
-                                id="clearCanvas"
-                                type="button"
-                                className="bg-gray-700 text-white px-6 py-3 rounded hover:bg-gray-500 transition">
-                                Clear Canvas
-                            </button>
-                        </div>
+                        <ClearCanvasButton />
                     </div>
                 </div>
             </div>

--- a/finite-automata-designer/src/app/dfa/[id]/page.tsx
+++ b/finite-automata-designer/src/app/dfa/[id]/page.tsx
@@ -15,6 +15,7 @@ import ExportTextArea from "@/app/components/editor/export/ExportTextArea";
 import InputString from "@/app/components/editor/InputString";
 import AlphabetInput from "@/app/components/editor/alphabet/AlphabetInput";
 import AlphabetLabel from "@/app/components/editor/alphabet/AlphabetLabel";
+import RunButton from "@/app/components/editor/RunButton";
 
 
 function DFAPageContent() {
@@ -192,13 +193,10 @@ function DFAPageContent() {
                             </button>
                     
                             {/* Run button to run the DFA with the given input string */}
-                            <button
-                                id="dfaRunBtn"
-                                type="button"
-                                className="flex-none px-8 py-3 bg-gray-700 text-white rounded hover:bg-black transition"
-                            >
-                                Run
-                            </button>
+                            <RunButton 
+                                type={"DFA"}
+                            />
+
                             {/* My Projects button to open the projects page that will list all of the users project when logged in */}
                             <Link
                                 href="/projects"

--- a/finite-automata-designer/src/app/dfa/[id]/page.tsx
+++ b/finite-automata-designer/src/app/dfa/[id]/page.tsx
@@ -9,6 +9,7 @@ import { FiniteAutomaton } from "@/lib/shared/types";
 import { getAutomaton } from "@/lib/automata/queries";
 import { SaveProjectModal } from "@/app/components/projects/SaveProjectModal";
 import Instructions from "@/app/components/editor/Instructions";
+import AutomataHeader from "@/app/components/editor/AutomataHeader";
 
 
 function DFAPageContent() {
@@ -113,27 +114,10 @@ function DFAPageContent() {
     return (
       <main className="min-h-screen bg-blue-100 flex flex-col items-center">
         {/* DFA title at the top */}
-        <h1 className="text-5xl font-bold text-center my-2 text-black ">
-            <span className="drop-shadow-[0_0_1px_rgba(0,0,0,0.7)]">
-                DFA: {name}
-            </span>
-            <span className="h-8 bg-gradient-to-b from-white/30 via-white/10 to-transparent opacity-20 rounded pointer-events-none"></span>
-        </h1>
-        {description && (
-            <p
-                className="
-                    mt-3
-                    max-w-3xl
-                    mx-auto
-                    px-4
-                    text-lg
-                    text-gray-600
-                    break-words
-                "
-            >
-                {description}
-            </p>
-        )}
+        <AutomataHeader
+            title={!name ? "Deterministic Finite Automata" : ("DFA: " + name)}
+            description={description}
+        />
         <div
             className="flex w-full"
         >

--- a/finite-automata-designer/src/app/dfa/[id]/page.tsx
+++ b/finite-automata-designer/src/app/dfa/[id]/page.tsx
@@ -16,6 +16,7 @@ import InputString from "@/app/components/editor/InputString";
 import AlphabetInput from "@/app/components/editor/alphabet/AlphabetInput";
 import AlphabetLabel from "@/app/components/editor/alphabet/AlphabetLabel";
 import RunButton from "@/app/components/editor/RunButton";
+import ProjectsButton from "@/app/components/editor/ProjectsButton";
 
 
 function DFAPageContent() {
@@ -198,12 +199,8 @@ function DFAPageContent() {
                             />
 
                             {/* My Projects button to open the projects page that will list all of the users project when logged in */}
-                            <Link
-                                href="/projects"
-                                className="flex-none px-8 py-3 bg-gray-700 text-white rounded hover:bg-black transition"
-                                >
-                                My Projects
-                            </Link>
+                            <ProjectsButton />
+                            
                         </div>
                     </div>
                     {/* Clear Canvas parent container */}

--- a/finite-automata-designer/src/app/dfa/[id]/page.tsx
+++ b/finite-automata-designer/src/app/dfa/[id]/page.tsx
@@ -2,7 +2,7 @@
 import Link from "next/link";
 import Script from 'next/script';
 import { useEffect, useState, Suspense, useRef } from "react";
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { toggle_visiblity } from "../../../../public/scripts/canvasUtil/canvasUtil";
 import { saveAutomaton, updateAutomaton } from "@/lib/automata/mutations";
 import { FiniteAutomaton } from "@/lib/shared/types";
@@ -22,6 +22,7 @@ function DFAPageContent() {
     const [description, setDescription] = useState<string | null>(null);
 
     const params = useParams();
+    const router = useRouter();
 
     const automatonId = params?.id as string;
 
@@ -86,12 +87,13 @@ function DFAPageContent() {
         console.log(serialized);
 
         try{
-            await saveAutomaton(serialized, newName, newDescription);
+            const finiteAutomataData = await saveAutomaton(serialized, newName, newDescription);
             alert("Automaton saved!");
+            router.push(`/dfa/${finiteAutomataData.id}`);
         }
-        catch (err) {
-            console.error(err);
-            alert("Save failed.");
+        catch (error) {
+            console.error(error);
+            alert("Save failed: " + error);
         }
     }
 
@@ -100,7 +102,7 @@ function DFAPageContent() {
         console.log(serialized);
 
         try{
-            await updateAutomaton(serialized);
+            await updateAutomaton(automatonId, serialized);
             alert("Automaton saved!");
         }
         catch (err) {

--- a/finite-automata-designer/src/app/dfa/page.tsx
+++ b/finite-automata-designer/src/app/dfa/page.tsx
@@ -9,6 +9,7 @@ import { createClient } from "@/lib/supabase/client";
 import { SaveProjectModal } from "../components/projects/SaveProjectModal";
 import Instructions from "../components/editor/Instructions";
 import AutomataHeader from "../components/editor/AutomataHeader";
+import ImportContainer from "../components/editor/ImportContainer";
 
 
 function DFAPageContent() {
@@ -16,7 +17,6 @@ function DFAPageContent() {
     const [hasMultiCharAlphabet, setHasMultiCharAlphabet] = useState(false);
     const [alphabetInput, setAlphabetInput] = useState("");
     const [exportOpen, setExportOpen] = useState(false);
-    const [importOpen, setImportOpen] = useState(false);
     const [isSaving, setIsSaving] = useState(false);
     const searchParams = useSearchParams();
     const id = searchParams?.get("id");
@@ -28,7 +28,6 @@ function DFAPageContent() {
     // onReady on the <Script> tag drains this once the script is ready.
     const pendingAutomaton = useRef<unknown>(null);
     const exportMenuRef = useRef<HTMLDivElement>(null);
-    const importMenuRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
 
@@ -198,75 +197,7 @@ function DFAPageContent() {
                         </div>
                     </div>
                     {/* Importing dropdowns container*/}
-                    <div className="flex gap-2 mt-2">
-                        <p className="text-lg">Import as: </p> 
-                        <div className="flex gap-2">
-                            {/* Importing options parent selector*/}
-                            <div className="relative inline-block text-left">
-                                <button
-                                    id="importMenuBtn"
-                                    type="button"
-                                    onClick={() => {
-                                        if (importMenuRef.current) toggle_visiblity(importMenuRef.current);
-                                        setImportOpen(prev => !prev);
-                                    }}
-                                    className="flex justify-center gap-x-1.5 rounded-md bg-gray-700 text-white px-2 py-1 text-md hover:bg-black transition"
-                                >
-                                    Import Options
-                                    <svg
-                                        className={`-mr-1 h-5 w-5 text-gray-400 h-4 w-4 transition-transform ${importOpen ? "rotate-180" : ""}`}
-                                        xmlns="http://www.w3.org/2000/svg"
-                                        viewBox="0 0 20 20"
-                                        fill="currentColor"
-                                        aria-hidden="true"
-                                    >
-                                        <path
-                                            fillRule="evenodd"
-                                            d="M5.23 7.21a.75.75 0 011.06.02L10 10.939l3.71-3.71a.75.75 0 111.06 1.06l-4.24 4.24a.75.75 0 01-1.06 0L5.25 8.27a.75.75 0 01-.02-1.06z"
-                                            clipRule="evenodd"
-                                        />
-                                    </svg>
-                                </button>
-                                {/* Import Menu options (SVG and LaTeX)*/}
-                                <div
-                                    ref={importMenuRef}
-                                    id="importMenu"
-                                    hidden
-                                    className="absolute mt-2 w-40 rounded-md bg-gray-700 shadow-lg z-20"
-                                >
-                                    <button
-                                    id="svgImportBtn"
-                                    type="button"
-                                    onClick={() => {
-                                        if (importMenuRef.current) toggle_visiblity(importMenuRef.current);
-                                        setImportOpen(false);
-                                    }}
-                                    className="block w-full px-4 py-2 text-left text-white hover:bg-gray-600"
-                                    >
-                                    Import as SVG
-                                    </button>
-                                    <button
-                                    id="latexImportBtn"
-                                    type="button"
-                                    onClick={() => {
-                                        if (importMenuRef.current) toggle_visiblity(importMenuRef.current);
-                                        setImportOpen(false);
-                                    }}
-                                    className="block w-full px-4 py-2 text-left text-white hover:bg-gray-600"
-                                    >
-                                    Import as LaTeX
-                                    </button>
-                                </div>
-                            </div>
-                            <button 
-                            id="confirmImport"
-                            className="flex justify-center gap-x-1.5 rounded-md bg-gray-700 text-white px-2 py-1 text-md hover:bg-black transition" 
-                            hidden
-                            >
-                                Draw Import
-                            </button>
-                        </div>
-                    </div>
+                    <ImportContainer />
                     
                     {/*Leave for now in case we turn back the UI for importing and exporting*/}
 

--- a/finite-automata-designer/src/app/dfa/page.tsx
+++ b/finite-automata-designer/src/app/dfa/page.tsx
@@ -2,7 +2,7 @@
 import Link from "next/link";
 import Script from 'next/script';
 import { useEffect, useState, Suspense, useRef } from "react";
-import { useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { toggle_visiblity } from "../../../public/scripts/canvasUtil/canvasUtil";
 import { saveAutomaton } from "@/lib/automata/mutations";
 import { createClient } from "@/lib/supabase/client";
@@ -19,6 +19,7 @@ function DFAPageContent() {
     const [isSaving, setIsSaving] = useState(false);
     const searchParams = useSearchParams();
     const id = searchParams?.get("id");
+    const router = useRouter();
 
     // Holds automaton data fetched before the canvas script has finished loading.
     // onReady on the <Script> tag drains this once the script is ready.
@@ -93,16 +94,17 @@ function DFAPageContent() {
         console.log(serialized);
 
         try{
-            await saveAutomaton(
+            const finiteAutomataData = await saveAutomaton(
                 serialized, 
                 (name.trim() === "") ? null : name.trim(), 
                 (description.trim() === "") ? null : description.trim(),
             );
             alert("Automaton saved!");
+            router.push(`/dfa/${finiteAutomataData.id}`);
         }
-        catch (err) {
-            console.error(err);
-            alert("Save failed: " + err);
+        catch (error) {
+            console.error(error);
+            alert("Save failed: " + error);
         }
     }
 

--- a/finite-automata-designer/src/app/dfa/page.tsx
+++ b/finite-automata-designer/src/app/dfa/page.tsx
@@ -7,13 +7,13 @@ import { toggle_visiblity } from "../../../public/scripts/canvasUtil/canvasUtil"
 import { saveAutomaton } from "@/lib/automata/mutations";
 import { createClient } from "@/lib/supabase/client";
 import { SaveProjectModal } from "../components/projects/SaveProjectModal";
+import { Instructions } from "../components/editor/Instructions";
 
 
 function DFAPageContent() {
 
     const [hasMultiCharAlphabet, setHasMultiCharAlphabet] = useState(false);
     const [alphabetInput, setAlphabetInput] = useState("");
-    const [instructionsOpen, setInstructionsOpen] = useState(false);
     const [exportOpen, setExportOpen] = useState(false);
     const [importOpen, setImportOpen] = useState(false);
     const [isSaving, setIsSaving] = useState(false);
@@ -126,43 +126,9 @@ function DFAPageContent() {
                 <Link href="/" className="px-6 py-3 bg-gray-700 text-white rounded hover:bg-black transition">
                     ← Back
                 </Link>
-                <div className="mt-6 pr-4 w-full text-black">
-                    <button
-                        type="button"
-                        onClick={() => setInstructionsOpen(prev => !prev)}
-                        className="flex items-center gap-2 px-4 py-2 bg-gray-700 text-white rounded hover:bg-black transition"
-                    >
-                        Instructions
-                        <svg
-                            className={`h-4 w-4 transition-transform ${instructionsOpen ? "rotate-180" : ""}`}
-                            xmlns="http://www.w3.org/2000/svg"
-                            viewBox="0 0 20 20"
-                            fill="currentColor"
-                        >
-                            <path 
-                                fillRule="evenodd" 
-                                d="M5.23 7.21a.75.75 0 011.06.02L10 10.939l3.71-3.71a.75.75 0 111.06 1.06l-4.24 4.24a.75.75 0 01-1.06 0L5.25 8.27a.75.75 0 01-.02-1.06z" 
-                                clipRule="evenodd" 
-                            />
-                        </svg>
-                    </button>
-                    {instructionsOpen && (
-                        <ul className="list-disc text-left mt-3 ml-4 text-sm space-y-1">
-                            <li><p className="font-semibold inline">Add a state: </p>Double-click on the canvas</li>
-                            <li><p className="font-semibold inline">Define start state: </p>Shift + Click empty space on canvas + Drag your desired start state</li>
-                            <li><p className="font-semibold inline">Add an arrow between states: </p>Shift + Click initial state + Drag the mouse to your desired terminal state</li>
-                            <li><p className="font-semibold inline">Add a looped arrow on a state: </p>Shift + Click existing state</li>
-                            <li><p className="font-semibold inline">Curve arrows: </p>Click your desired arrow and drag in the direction you wish to curve it</li>
-                            <li><p className="font-semibold inline">Move anything: </p>Click + Drag it around</li>
-                            <li><p className="font-semibold inline">Delete anything: </p>Click it and press the delete key (not backspace)</li>
-                            <li><p className="font-semibold inline">Make accept state: </p>Double-click an existing state</li>
-                            <li><p className="font-semibold inline">Type onto arrow or state: </p>Click on desired state, then begin typing. Click again anywhere else to submit</li>
-                            <li><p className="font-semibold inline">Type numeric subscript: </p>Put an underscore before the number (ex: &quot;q_0&quot;)</li>
-                            <li><p className="font-semibold inline">Set alphabet: </p>Type a comma-separated list of all the characters you wish to define for your DFA. Press Enter to submit</li>
-                            <li><p className="font-semibold inline">Run DFA: </p>Type an input string containing only the characters from your alphabet. Press Enter to submit</li>
-                        </ul>
-                    )}
-                </div>
+                <Instructions 
+                    type={"DFA"}
+                />
             </div>
             {/* Canvas parent div*/}
             <div>

--- a/finite-automata-designer/src/app/dfa/page.tsx
+++ b/finite-automata-designer/src/app/dfa/page.tsx
@@ -13,6 +13,7 @@ import ExportContainer from "../components/editor/export/ExportContainer";
 import ExportTextArea from "../components/editor/export/ExportTextArea";
 import ImportTextArea from "../components/editor/import/ImportTextArea";
 import InputString from "../components/editor/InputString";
+import AlphabetInput from "../components/editor/alphabet/AlphabetInput";
 
 
 function DFAPageContent() {
@@ -164,7 +165,7 @@ function DFAPageContent() {
                         <div id='inputDiv' className="flex flex-col self-center w-full max-w-md text-black">
                             {/* Textbox for inputting strings */}
                             <InputString />
-                            
+
                             <div className="min-h-[3rem]">
                                 {hasMultiCharAlphabet && (
                                     <div className="w-full rounded border border-red-300 bg-red-100 px-3 py-2">
@@ -179,20 +180,8 @@ function DFAPageContent() {
                             <label id="alphabetLabel" htmlFor="alphabet" className="block mb-1 text-gray-700 text-xl font-bold">
                                 Alphabet: {"{0,1}"}
                             </label>
-                            <input
-                                id="alphabet"
-                                type="text"
-                                placeholder="Enter an alphabet..."
-                                className="w-full px-4 py-2 border border-gray-400 rounded shadow-sm bg-white focus:outline-none focus:ring-2 focus:ring-blue-400"
-                                //onChange={(e) => setAlphabetDraft(e.target.value)}
-                                // Loose focus after you press enter
-                                onKeyDown={(e) => {
-                                    if (e.key === "Enter") {
-                                        e.currentTarget.blur();
-                                        //setAlphabetInput(alphabetDraft.trim());
-                                    }
-                                }}
-                            />
+                            
+                            <AlphabetInput />
                         </div>
                         <div className="flex flex-wrap self-center gap-5">
                             {/* Save button to save the DFA to the database only if the user is logged in */}

--- a/finite-automata-designer/src/app/dfa/page.tsx
+++ b/finite-automata-designer/src/app/dfa/page.tsx
@@ -2,10 +2,9 @@
 import Link from "next/link";
 import Script from 'next/script';
 import { useEffect, useState, Suspense, useRef } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter } from "next/navigation";
 import { toggle_visiblity } from "../../../public/scripts/canvasUtil/canvasUtil";
 import { saveAutomaton } from "@/lib/automata/mutations";
-import { createClient } from "@/lib/supabase/client";
 import { SaveProjectModal } from "../components/projects/SaveProjectModal";
 
 
@@ -17,13 +16,10 @@ function DFAPageContent() {
     const [exportOpen, setExportOpen] = useState(false);
     const [importOpen, setImportOpen] = useState(false);
     const [isSaving, setIsSaving] = useState(false);
-    const searchParams = useSearchParams();
-    const id = searchParams?.get("id");
     const router = useRouter();
 
     // Holds automaton data fetched before the canvas script has finished loading.
     // onReady on the <Script> tag drains this once the script is ready.
-    const pendingAutomaton = useRef<unknown>(null);
     const exportMenuRef = useRef<HTMLDivElement>(null);
     const importMenuRef = useRef<HTMLDivElement>(null);
 
@@ -49,44 +45,6 @@ function DFAPageContent() {
 
     }, [alphabetInput]);
 
-    useEffect(() => {
-        // Clear stale pending data whenever the target id changes
-        pendingAutomaton.current = null;
-
-        async function loadAutomaton(){
-            if(!id){
-                return;
-            }
-
-            const supabase = createClient();
-
-            const { data, error } = await supabase
-                .from("finite_automata")
-                .select("automaton")
-                .eq("id",id)
-                .single();
-
-            if(error){
-                console.error("Error loading automaton: ", error);
-                return;
-            }
-
-            if(!data){
-                console.log("No data");
-                return;
-            }
-
-            if (typeof window.loadDFAIntoCanvas === 'function') {
-                // Canvas script is already loaded — call directly.
-                window.loadDFAIntoCanvas(data.automaton);
-            } else {
-                // Canvas script hasn't finished loading yet (production race).
-                // Store the data so the onReady callback can deliver it once ready.
-                pendingAutomaton.current = data.automaton;
-            }
-        }
-        loadAutomaton();
-    },[id]);
 
     async function handleSave(name: string, description: string){
 
@@ -445,15 +403,6 @@ function DFAPageContent() {
             type="module"
             strategy="afterInteractive"
             crossOrigin="anonymous"
-            onReady={() => {
-                // Fires when the script first loads AND after every subsequent
-                // component mount where the script is already cached.
-                // Delivers any automaton data that arrived before the script was ready.
-                if (pendingAutomaton.current !== null) {
-                    window.loadDFAIntoCanvas(pendingAutomaton.current);
-                    pendingAutomaton.current = null;
-                }
-            }}
         />
       </main>
 

--- a/finite-automata-designer/src/app/dfa/page.tsx
+++ b/finite-automata-designer/src/app/dfa/page.tsx
@@ -83,32 +83,34 @@ function DFAPageContent() {
         <div
             className="flex w-full"
         >
-            {/* Back Button + Instructions parent div*/}
+            {/* Back Button + Instructions parent div */}
             <div className="flex-1 flex flex-col items-start h-13 pl-5" >
                 {/* Back Button to return to Home Page */}
                 <BackButton />
 
+                {/* Instructions dropdown */}
                 <Instructions 
                     type={"DFA"}
                 />
 
             </div>
-            
-            {/* Canvas parent div*/}
+
+            {/* Canvas parent div */}
             <div>
                 <div id="canvasDiv" className="flex flex-col text-black">
                     {/* Canvas for drawing FSM */}
                     <canvas id="DFACanvas" width={800} height={600} className="rounded-lg border border-gray-400"></canvas>
 
-                    {/* Exporting dropdowns container*/}
+                    {/* Exporting dropdowns container */}
                     <ExportContainer />
 
-                    {/* Importing dropdowns container*/}
+                    {/* Importing dropdowns container */}
                     <ImportContainer />
                     
-                    
+                    {/* Exporting text area */}
                     <ExportTextArea />
 
+                    {/* Importing text area */}
                     <ImportTextArea />
                 
                 </div>
@@ -121,11 +123,13 @@ function DFAPageContent() {
                         <div id='inputDiv' className="flex flex-col self-center w-full max-w-md text-black">
                             {/* Textbox for inputting strings */}
                             <InputString />
-
+                            
+                            {/* Alphabet display */}
                             <AlphabetLabel 
                                 hasMultiCharAlphabet={hasMultiCharAlphabet}
                             />
                             
+                            {/* Input box for new alphabet */}
                             <AlphabetInput />
                             
                         </div>

--- a/finite-automata-designer/src/app/dfa/page.tsx
+++ b/finite-automata-designer/src/app/dfa/page.tsx
@@ -12,6 +12,7 @@ import ImportContainer from "../components/editor/import/ImportContainer";
 import ExportContainer from "../components/editor/export/ExportContainer";
 import ExportTextArea from "../components/editor/export/ExportTextArea";
 import ImportTextArea from "../components/editor/import/ImportTextArea";
+import InputString from "../components/editor/InputString";
 
 
 function DFAPageContent() {
@@ -162,21 +163,8 @@ function DFAPageContent() {
                     <div className="flex flex-col gap-5">
                         <div id='inputDiv' className="flex flex-col self-center w-full max-w-md text-black">
                             {/* Textbox for inputting strings */}
-                            <label htmlFor="inputString" className="block mb-1 text-gray-700 text-xl font-bold">
-                                Input:
-                            </label>
-                            <input
-                                id="inputString"
-                                type="text"
-                                placeholder="Enter a string..."
-                                className="w-full px-4 py-2 border border-gray-400 rounded shadow-sm bg-white focus:outline-none focus:ring-2 focus:ring-blue-400"
-                                // Loose focus after you press enter
-                                onKeyDown={(e) => {
-                                    if (e.key === "Enter") {
-                                        e.currentTarget.blur();
-                                    }
-                                }}
-                            />
+                            <InputString />
+                            
                             <div className="min-h-[3rem]">
                                 {hasMultiCharAlphabet && (
                                     <div className="w-full rounded border border-red-300 bg-red-100 px-3 py-2">

--- a/finite-automata-designer/src/app/dfa/page.tsx
+++ b/finite-automata-designer/src/app/dfa/page.tsx
@@ -19,6 +19,7 @@ import RunButton from "../components/editor/RunButton";
 import ProjectsButton from "../components/editor/ProjectsButton";
 import ClearCanvasButton from "../components/editor/ClearCanvasButton";
 import BackButton from "../components/editor/BackButton";
+import SaveActions from '../components/editor/SaveActions';
 
 
 function DFAPageContent() {
@@ -183,13 +184,17 @@ function DFAPageContent() {
                         </div>
                         <div className="flex flex-wrap self-center gap-5">
                             {/* Save button to save the DFA to the database only if the user is logged in */}
-                            <button
+                            {/* <button
                                 type="button"
                                 onClick={() => setIsSaving(true)}
                                 className="flex-none px-8 py-3 bg-gray-700 text-white rounded hover:bg-black transition"
                             >
                                 Save
-                            </button>
+                            </button> */}
+
+                            <SaveActions
+                                onSave={() => setIsSaving(true)}
+                            />
                     
                             {/* Run button to run the DFA with the given input string */}
                             <RunButton 

--- a/finite-automata-designer/src/app/dfa/page.tsx
+++ b/finite-automata-designer/src/app/dfa/page.tsx
@@ -184,14 +184,6 @@ function DFAPageContent() {
                         </div>
                         <div className="flex flex-wrap self-center gap-5">
                             {/* Save button to save the DFA to the database only if the user is logged in */}
-                            {/* <button
-                                type="button"
-                                onClick={() => setIsSaving(true)}
-                                className="flex-none px-8 py-3 bg-gray-700 text-white rounded hover:bg-black transition"
-                            >
-                                Save
-                            </button> */}
-
                             <SaveActions
                                 onSave={() => setIsSaving(true)}
                             />

--- a/finite-automata-designer/src/app/dfa/page.tsx
+++ b/finite-automata-designer/src/app/dfa/page.tsx
@@ -8,6 +8,7 @@ import { saveAutomaton } from "@/lib/automata/mutations";
 import { createClient } from "@/lib/supabase/client";
 import { SaveProjectModal } from "../components/projects/SaveProjectModal";
 import Instructions from "../components/editor/Instructions";
+import AutomataHeader from "../components/editor/AutomataHeader";
 
 
 function DFAPageContent() {
@@ -20,6 +21,8 @@ function DFAPageContent() {
     const searchParams = useSearchParams();
     const id = searchParams?.get("id");
     const router = useRouter();
+
+    const title: string = "Deterministic Finite Automata"
 
     // Holds automaton data fetched before the canvas script has finished loading.
     // onReady on the <Script> tag drains this once the script is ready.
@@ -111,12 +114,9 @@ function DFAPageContent() {
     return (
       <main className="min-h-screen bg-blue-100 flex flex-col items-center">
         {/* DFA title at the top */}
-        <h1 className="text-5xl font-bold text-center my-2 text-black ">
-            <span className="drop-shadow-[0_0_1px_rgba(0,0,0,0.7)]">
-                Deterministic Finite Automata
-            </span>
-            <span className="h-8 bg-gradient-to-b from-white/30 via-white/10 to-transparent opacity-20 rounded pointer-events-none"></span>
-        </h1>
+        <AutomataHeader
+            title={title}
+        />
         <div
             className="flex w-full"
         >

--- a/finite-automata-designer/src/app/dfa/page.tsx
+++ b/finite-automata-designer/src/app/dfa/page.tsx
@@ -17,6 +17,7 @@ import AlphabetInput from "../components/editor/alphabet/AlphabetInput";
 import AlphabetLabel from "../components/editor/alphabet/AlphabetLabel";
 import RunButton from "../components/editor/RunButton";
 import ProjectsButton from "../components/editor/ProjectsButton";
+import ClearCanvasButton from "../components/editor/ClearCanvasButton";
 
 
 function DFAPageContent() {
@@ -192,19 +193,12 @@ function DFAPageContent() {
 
                             {/* My Projects button to open the projects page that will list all of the users project when logged in */}
                             <ProjectsButton />
-                            
+
                         </div>
                     </div>
                     {/* Clear Canvas parent container */}
                     <div>
-                        <div className="mt-4 flex justify-center">
-                            <button
-                                id="clearCanvas"
-                                type="button"
-                                className="bg-gray-700 text-white px-6 py-3 rounded hover:bg-gray-500 transition">
-                                Clear Canvas
-                            </button>
-                        </div>
+                        <ClearCanvasButton />
                     </div>
                 </div>
             </div>

--- a/finite-automata-designer/src/app/dfa/page.tsx
+++ b/finite-automata-designer/src/app/dfa/page.tsx
@@ -93,6 +93,7 @@ function DFAPageContent() {
                 />
 
             </div>
+            
             {/* Canvas parent div*/}
             <div>
                 <div id="canvasDiv" className="flex flex-col text-black">
@@ -105,15 +106,6 @@ function DFAPageContent() {
                     {/* Importing dropdowns container*/}
                     <ImportContainer />
                     
-                    {/*Leave for now in case we turn back the UI for importing and exporting*/}
-
-                    {/* <div className="text-center text-black mt-2">
-                        Export as: <button id='svgExportBtn' type="button" className="cursor-pointer">SVG</button>
-                        {' | '} <button id='latexExportBtn' type="button" className="cursor-pointer">LaTeX</button>
-                        <br />
-                        Import as: <button id='svgImportBtn' type="button" className="cursor-pointer">SVG</button>
-                        {' | '} <button id='latexImportBtn' type="button" className="cursor-pointer">LaTeX</button>
-                    </div> */}
                     
                     <ExportTextArea />
 

--- a/finite-automata-designer/src/app/dfa/page.tsx
+++ b/finite-automata-designer/src/app/dfa/page.tsx
@@ -14,6 +14,7 @@ import ExportTextArea from "../components/editor/export/ExportTextArea";
 import ImportTextArea from "../components/editor/import/ImportTextArea";
 import InputString from "../components/editor/InputString";
 import AlphabetInput from "../components/editor/alphabet/AlphabetInput";
+import AlphabetLabel from "../components/editor/alphabet/AlphabetLabel";
 
 
 function DFAPageContent() {
@@ -166,20 +167,9 @@ function DFAPageContent() {
                             {/* Textbox for inputting strings */}
                             <InputString />
 
-                            <div className="min-h-[3rem]">
-                                {hasMultiCharAlphabet && (
-                                    <div className="w-full rounded border border-red-300 bg-red-100 px-3 py-2">
-                                        <p className="text-sm text-red-700 font-semibold">
-                                            Multi-character element detected in alphabet. Please separate elements
-                                            in your input string with commas or spaces.
-                                        </p>
-                                    </div>
-                                )}
-                            </div>
-                            {/* Textbox for inputting the alphabet */}
-                            <label id="alphabetLabel" htmlFor="alphabet" className="block mb-1 text-gray-700 text-xl font-bold">
-                                Alphabet: {"{0,1}"}
-                            </label>
+                            <AlphabetLabel 
+                                hasMultiCharAlphabet={hasMultiCharAlphabet}
+                            />
                             
                             <AlphabetInput />
                         </div>

--- a/finite-automata-designer/src/app/dfa/page.tsx
+++ b/finite-automata-designer/src/app/dfa/page.tsx
@@ -15,6 +15,7 @@ import ImportTextArea from "../components/editor/import/ImportTextArea";
 import InputString from "../components/editor/InputString";
 import AlphabetInput from "../components/editor/alphabet/AlphabetInput";
 import AlphabetLabel from "../components/editor/alphabet/AlphabetLabel";
+import RunButton from "../components/editor/RunButton";
 
 
 function DFAPageContent() {
@@ -184,13 +185,10 @@ function DFAPageContent() {
                             </button>
                     
                             {/* Run button to run the DFA with the given input string */}
-                            <button
-                                id="dfaRunBtn"
-                                type="button"
-                                className="flex-none px-8 py-3 bg-gray-700 text-white rounded hover:bg-black transition"
-                            >
-                                Run
-                            </button>
+                            <RunButton 
+                                type={"DFA"}
+                            />
+
                             {/* My Projects button to open the projects page that will list all of the users project when logged in */}
                             <Link
                                 href="/projects"

--- a/finite-automata-designer/src/app/dfa/page.tsx
+++ b/finite-automata-designer/src/app/dfa/page.tsx
@@ -16,6 +16,7 @@ import InputString from "../components/editor/InputString";
 import AlphabetInput from "../components/editor/alphabet/AlphabetInput";
 import AlphabetLabel from "../components/editor/alphabet/AlphabetLabel";
 import RunButton from "../components/editor/RunButton";
+import ProjectsButton from "../components/editor/ProjectsButton";
 
 
 function DFAPageContent() {
@@ -190,12 +191,8 @@ function DFAPageContent() {
                             />
 
                             {/* My Projects button to open the projects page that will list all of the users project when logged in */}
-                            <Link
-                                href="/projects"
-                                className="flex-none px-8 py-3 bg-gray-700 text-white rounded hover:bg-black transition"
-                                >
-                                My Projects
-                            </Link>
+                            <ProjectsButton />
+                            
                         </div>
                     </div>
                     {/* Clear Canvas parent container */}

--- a/finite-automata-designer/src/app/dfa/page.tsx
+++ b/finite-automata-designer/src/app/dfa/page.tsx
@@ -3,20 +3,19 @@ import Link from "next/link";
 import Script from 'next/script';
 import { useEffect, useState, Suspense, useRef } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { toggle_visiblity } from "../../../public/scripts/canvasUtil/canvasUtil";
 import { saveAutomaton } from "@/lib/automata/mutations";
 import { createClient } from "@/lib/supabase/client";
 import { SaveProjectModal } from "../components/projects/SaveProjectModal";
 import Instructions from "../components/editor/Instructions";
 import AutomataHeader from "../components/editor/AutomataHeader";
 import ImportContainer from "../components/editor/ImportContainer";
+import ExportContainer from "../components/editor/ExportContainer";
 
 
 function DFAPageContent() {
 
     const [hasMultiCharAlphabet, setHasMultiCharAlphabet] = useState(false);
     const [alphabetInput, setAlphabetInput] = useState("");
-    const [exportOpen, setExportOpen] = useState(false);
     const [isSaving, setIsSaving] = useState(false);
     const searchParams = useSearchParams();
     const id = searchParams?.get("id");
@@ -27,7 +26,6 @@ function DFAPageContent() {
     // Holds automaton data fetched before the canvas script has finished loading.
     // onReady on the <Script> tag drains this once the script is ready.
     const pendingAutomaton = useRef<unknown>(null);
-    const exportMenuRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
 
@@ -135,67 +133,7 @@ function DFAPageContent() {
                     {/* Canvas for drawing FSM */}
                     <canvas id="DFACanvas" width={800} height={600} className="rounded-lg border border-gray-400"></canvas>
                     {/* Exporting dropdowns container*/}
-                    <div className="flex gap-2">
-                        <p className="text-lg mt-5">Export as: </p> 
-                        <div className="relative inline-block text-left mt-5">
-                            {/* Exporting options parent selector*/}
-                            <button
-                                id="exportMenuBtn"
-                                type="button"
-                                onClick={() => {
-                                    if (exportMenuRef.current) toggle_visiblity(exportMenuRef.current);
-                                    setExportOpen(prev => !prev);
-                                }}
-                                className="flex justify-center gap-x-1.5 rounded-md bg-gray-700 text-white px-2 py-1 text-md hover:bg-black transition"
-                            >
-                                Export Options
-                                <svg
-                                    className={`-mr-1 h-5 w-5 text-gray-400 h-4 w-4 transition-transform ${exportOpen ? "rotate-180" : ""}`}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                    viewBox="0 0 20 20"
-                                    fill="currentColor"
-                                    aria-hidden="true"
-                                >
-                                    <path
-                                        fillRule="evenodd"
-                                        d="M5.23 7.21a.75.75 0 011.06.02L10 10.939l3.71-3.71a.75.75 0 111.06 1.06l-4.24 4.24a.75.75 0 01-1.06 0L5.25 8.27a.75.75 0 01-.02-1.06z"
-                                        clipRule="evenodd"
-                                    />
-                                </svg>
-                            </button>
-                            
-                            {/* Export Menu options (SVG and LaTeX)*/}
-                            <div
-                                ref={exportMenuRef}
-                                id="exportMenu"
-                                hidden
-                                className="absolute mt-2 w-40 rounded-md bg-gray-700 shadow-lg z-20"
-                            >
-                                <button
-                                    id="svgExportBtn"
-                                    type="button"
-                                    onClick={() => {
-                                        if (exportMenuRef.current) toggle_visiblity(exportMenuRef.current);
-                                        setExportOpen(false);
-                                    }}
-                                    className="block w-full px-4 py-2 text-left text-white hover:bg-gray-600"
-                                >
-                                    SVG
-                                </button>
-                                <button
-                                    id="latexExportBtn"
-                                    type="button"
-                                    onClick={() => {
-                                        if (exportMenuRef.current) toggle_visiblity(exportMenuRef.current);
-                                        setExportOpen(false);
-                                    }}
-                                    className="block w-full px-4 py-2 text-left text-white hover:bg-gray-600"
-                                >
-                                    LaTeX
-                                </button>
-                            </div>
-                        </div>
-                    </div>
+                    <ExportContainer />
                     {/* Importing dropdowns container*/}
                     <ImportContainer />
                     

--- a/finite-automata-designer/src/app/dfa/page.tsx
+++ b/finite-automata-designer/src/app/dfa/page.tsx
@@ -87,25 +87,22 @@ function DFAPageContent() {
         loadAutomaton();
     },[id]);
 
-    async function handleSave(){
-        const supabase = createClient();
-        const { data: { user } } = await supabase.auth.getUser();
-
-        if(!user){
-            alert("Yout must be logged in to save.");
-            return;
-        }
+    async function handleSave(name: string, description: string){
 
         const serialized = window.exportDFA();
         console.log(serialized);
 
         try{
-            await saveAutomaton(user.id, serialized);
+            await saveAutomaton(
+                serialized, 
+                (name.trim() === "") ? null : name.trim(), 
+                (description.trim() === "") ? null : description.trim(),
+            );
             alert("Automaton saved!");
         }
         catch (err) {
             console.error(err);
-            alert("Save failed.");
+            alert("Save failed: " + err);
         }
     }
 
@@ -435,6 +432,8 @@ function DFAPageContent() {
 
         <SaveProjectModal 
             isOpen={isSaving}
+            initialName={null}
+            initialDescription={null}
             onClose={() => setIsSaving(false)}
             onSave={handleSave}
         />

--- a/finite-automata-designer/src/app/dfa/page.tsx
+++ b/finite-automata-designer/src/app/dfa/page.tsx
@@ -6,6 +6,7 @@ import { useSearchParams } from "next/navigation";
 import { toggle_visiblity } from "../../../public/scripts/canvasUtil/canvasUtil";
 import { saveAutomaton } from "@/lib/saveAutomaton";
 import { createClient } from "@/lib/supabase/client";
+import { SaveProjectModal } from "../components/projects/SaveProjectModal";
 
 
 function DFAPageContent() {
@@ -15,6 +16,7 @@ function DFAPageContent() {
     const [instructionsOpen, setInstructionsOpen] = useState(false);
     const [exportOpen, setExportOpen] = useState(false);
     const [importOpen, setImportOpen] = useState(false);
+    const [isSaving, setIsSaving] = useState(false);
     const searchParams = useSearchParams();
     const id = searchParams?.get("id");
 
@@ -393,7 +395,7 @@ function DFAPageContent() {
                             {/* Save button to save the DFA to the database only if the user is logged in */}
                             <button
                                 type="button"
-                                onClick={handleSave}
+                                onClick={() => setIsSaving(true)}
                                 className="flex-none px-8 py-3 bg-gray-700 text-white rounded hover:bg-black transition"
                             >
                                 Save
@@ -430,6 +432,12 @@ function DFAPageContent() {
                 </div>
             </div>
         </div>
+
+        <SaveProjectModal 
+            isOpen={isSaving}
+            onClose={() => setIsSaving(false)}
+            onSave={handleSave}
+        />
 
         <Script
             src="/scripts/dfa/dfaCanvas.js"

--- a/finite-automata-designer/src/app/dfa/page.tsx
+++ b/finite-automata-designer/src/app/dfa/page.tsx
@@ -10,6 +10,7 @@ import Instructions from "../components/editor/Instructions";
 import AutomataHeader from "../components/editor/AutomataHeader";
 import ImportContainer from "../components/editor/import/ImportContainer";
 import ExportContainer from "../components/editor/export/ExportContainer";
+import ExportTextArea from "../components/editor/export/ExportTextArea";
 
 
 function DFAPageContent() {
@@ -146,19 +147,9 @@ function DFAPageContent() {
                         Import as: <button id='svgImportBtn' type="button" className="cursor-pointer">SVG</button>
                         {' | '} <button id='latexImportBtn' type="button" className="cursor-pointer">LaTeX</button>
                     </div> */}
-                    <div id="exportOutputContainer" hidden className="text-center">
-                        <textarea 
-                        disabled
-                        tabIndex={-1}
-                        id="output"
-                        className="w-full h-24 mt-2 border border-gray-400 rounded text-black bg-white select-none" 
-                        placeholder="Export will appear here...">
-                        </textarea>
-                        <div className="flex gap-4 justify-center text-black">
-                            <button id='hideOutput' type="button" className="cursor-pointer text-center text-decoration underline">Hide Export Output</button>
-                            <button id='copyOutput' type="button" className="cursor-pointer text-center text-decoration underline">Copy Output</button>
-                        </div>
-                    </div>
+                    
+                    <ExportTextArea />
+
                     <div id="importInputContainer" hidden className="text-center">
                         <textarea 
                         tabIndex={-1}

--- a/finite-automata-designer/src/app/dfa/page.tsx
+++ b/finite-automata-designer/src/app/dfa/page.tsx
@@ -11,6 +11,7 @@ import AutomataHeader from "../components/editor/AutomataHeader";
 import ImportContainer from "../components/editor/import/ImportContainer";
 import ExportContainer from "../components/editor/export/ExportContainer";
 import ExportTextArea from "../components/editor/export/ExportTextArea";
+import ImportTextArea from "../components/editor/import/ImportTextArea";
 
 
 function DFAPageContent() {
@@ -150,18 +151,7 @@ function DFAPageContent() {
                     
                     <ExportTextArea />
 
-                    <div id="importInputContainer" hidden className="text-center">
-                        <textarea 
-                        tabIndex={-1}
-                        id="input"
-                        className="w-full h-24 mt-2 border border-gray-400 rounded text-black bg-white select-none" 
-                        placeholder="Enter the input data that you exported EXCLUSIVELY from this FA designer goes here...">
-                        </textarea>
-                        <div className="flex gap-4 justify-center text-black">
-                            <button id='hideInput' type="button" className="cursor-pointer text-center text-decoration underline">Hide Input</button>
-                            <button id='clearInput' type="button" className="cursor-pointer text-center text-decoration underline">Clear Input</button>
-                        </div>
-                    </div>
+                    <ImportTextArea />
                 
                 </div>
             </div>

--- a/finite-automata-designer/src/app/dfa/page.tsx
+++ b/finite-automata-designer/src/app/dfa/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import Link from "next/link";
+
 import Script from 'next/script';
 import { useEffect, useState, Suspense, useRef } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
@@ -18,6 +18,7 @@ import AlphabetLabel from "../components/editor/alphabet/AlphabetLabel";
 import RunButton from "../components/editor/RunButton";
 import ProjectsButton from "../components/editor/ProjectsButton";
 import ClearCanvasButton from "../components/editor/ClearCanvasButton";
+import BackButton from "../components/editor/BackButton";
 
 
 function DFAPageContent() {
@@ -122,26 +123,29 @@ function DFAPageContent() {
         <AutomataHeader
             title={title}
         />
+
         <div
             className="flex w-full"
         >
             {/* Back Button + Instructions parent div*/}
             <div className="flex-1 flex flex-col items-start h-13 pl-5" >
                 {/* Back Button to return to Home Page */}
-                <Link href="/" className="px-6 py-3 bg-gray-700 text-white rounded hover:bg-black transition">
-                    ← Back
-                </Link>
+                <BackButton />
+
                 <Instructions 
                     type={"DFA"}
                 />
+
             </div>
             {/* Canvas parent div*/}
             <div>
                 <div id="canvasDiv" className="flex flex-col text-black">
                     {/* Canvas for drawing FSM */}
                     <canvas id="DFACanvas" width={800} height={600} className="rounded-lg border border-gray-400"></canvas>
+
                     {/* Exporting dropdowns container*/}
                     <ExportContainer />
+
                     {/* Importing dropdowns container*/}
                     <ImportContainer />
                     
@@ -175,6 +179,7 @@ function DFAPageContent() {
                             />
                             
                             <AlphabetInput />
+                            
                         </div>
                         <div className="flex flex-wrap self-center gap-5">
                             {/* Save button to save the DFA to the database only if the user is logged in */}

--- a/finite-automata-designer/src/app/dfa/page.tsx
+++ b/finite-automata-designer/src/app/dfa/page.tsx
@@ -8,8 +8,8 @@ import { createClient } from "@/lib/supabase/client";
 import { SaveProjectModal } from "../components/projects/SaveProjectModal";
 import Instructions from "../components/editor/Instructions";
 import AutomataHeader from "../components/editor/AutomataHeader";
-import ImportContainer from "../components/editor/ImportContainer";
-import ExportContainer from "../components/editor/ExportContainer";
+import ImportContainer from "../components/editor/import/ImportContainer";
+import ExportContainer from "../components/editor/export/ExportContainer";
 
 
 function DFAPageContent() {

--- a/finite-automata-designer/src/app/dfa/page.tsx
+++ b/finite-automata-designer/src/app/dfa/page.tsx
@@ -7,7 +7,7 @@ import { toggle_visiblity } from "../../../public/scripts/canvasUtil/canvasUtil"
 import { saveAutomaton } from "@/lib/automata/mutations";
 import { createClient } from "@/lib/supabase/client";
 import { SaveProjectModal } from "../components/projects/SaveProjectModal";
-import { Instructions } from "../components/editor/Instructions";
+import Instructions from "../components/editor/Instructions";
 
 
 function DFAPageContent() {

--- a/finite-automata-designer/src/app/dfa/page.tsx
+++ b/finite-automata-designer/src/app/dfa/page.tsx
@@ -4,7 +4,7 @@ import Script from 'next/script';
 import { useEffect, useState, Suspense, useRef } from "react";
 import { useSearchParams } from "next/navigation";
 import { toggle_visiblity } from "../../../public/scripts/canvasUtil/canvasUtil";
-import { saveAutomaton } from "@/lib/saveAutomaton";
+import { saveAutomaton } from "@/lib/automata/mutations";
 import { createClient } from "@/lib/supabase/client";
 import { SaveProjectModal } from "../components/projects/SaveProjectModal";
 

--- a/finite-automata-designer/src/app/nfa/page.tsx
+++ b/finite-automata-designer/src/app/nfa/page.tsx
@@ -5,8 +5,8 @@ import { useEffect, useState, Suspense } from "react";
 // import { useSearchParams } from "next/navigation";
 import Instructions from "../components/editor/Instructions";
 import AutomataHeader from "../components/editor/AutomataHeader";
-import ImportContainer from "../components/editor/ImportContainer";
-import ExportContainer from "../components/editor/ExportContainer";
+import ImportContainer from "../components/editor/import/ImportContainer";
+import ExportContainer from "../components/editor/export/ExportContainer";
 
 
 function NFAPageContent() {

--- a/finite-automata-designer/src/app/nfa/page.tsx
+++ b/finite-automata-designer/src/app/nfa/page.tsx
@@ -8,6 +8,7 @@ import AutomataHeader from "../components/editor/AutomataHeader";
 import ImportContainer from "../components/editor/import/ImportContainer";
 import ExportContainer from "../components/editor/export/ExportContainer";
 import ExportTextArea from "../components/editor/export/ExportTextArea";
+import ImportTextArea from "../components/editor/import/ImportTextArea";
 
 
 function NFAPageContent() {
@@ -81,18 +82,7 @@ function NFAPageContent() {
 
                     <ExportTextArea />
 
-                    <div id="importInputContainer" hidden className="text-center">
-                        <textarea
-                        tabIndex={-1}
-                        id="input"
-                        className="w-full h-24 mt-2 border border-gray-400 rounded text-black bg-white select-none"
-                        placeholder="Enter the input data that you exported EXCLUSIVELY from this FA designer goes here...">
-                        </textarea>
-                        <div className="flex gap-4 justify-center text-black">
-                            <button id='hideInput' type="button" className="cursor-pointer text-center text-decoration underline">Hide Input</button>
-                            <button id='clearInput' type="button" className="cursor-pointer text-center text-decoration underline">Clear Input</button>
-                        </div>
-                    </div>
+                    <ImportTextArea />
 
                 </div>
             </div>

--- a/finite-automata-designer/src/app/nfa/page.tsx
+++ b/finite-automata-designer/src/app/nfa/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import Link from "next/link";
+
 import Script from 'next/script';
 import { useEffect, useState, Suspense } from "react";
 // import { useSearchParams } from "next/navigation";
@@ -15,6 +15,7 @@ import AlphabetLabel from "../components/editor/alphabet/AlphabetLabel";
 import RunButton from "../components/editor/RunButton";
 import ProjectsButton from "../components/editor/ProjectsButton";
 import ClearCanvasButton from "../components/editor/ClearCanvasButton";
+import BackButton from "../components/editor/BackButton";
 
 
 function NFAPageContent() {
@@ -55,24 +56,27 @@ function NFAPageContent() {
         <AutomataHeader
             title={title}
         />
+
         <div className="flex w-full">
             {/* Back Button + Instructions parent div*/}
             <div className="flex-1 flex flex-col items-start h-13 pl-5" >
                 {/* Back Button to return to Home Page */}
-                <Link href="/" className="px-6 py-3 bg-gray-700 text-white rounded hover:bg-black transition">
-                    ← Back
-                </Link>
+                <BackButton />
+
                 <Instructions
                     type={"NFA"}
                 />
+
             </div>
             {/* Canvas parent div*/}
             <div>
                 <div id="canvasDiv" className="flex flex-col text-black">
                     {/* Canvas for drawing FSM */}
                     <canvas id="NFACanvas" width={800} height={600} className="rounded-lg border border-gray-400"></canvas>
+
                     {/* Exporting dropdowns container*/}
                     <ExportContainer />
+
                     {/* Importing dropdowns container*/}
                     <ImportContainer />
 

--- a/finite-automata-designer/src/app/nfa/page.tsx
+++ b/finite-automata-designer/src/app/nfa/page.tsx
@@ -12,6 +12,7 @@ import ImportTextArea from "../components/editor/import/ImportTextArea";
 import InputString from "../components/editor/InputString";
 import AlphabetInput from "../components/editor/alphabet/AlphabetInput";
 import AlphabetLabel from "../components/editor/alphabet/AlphabetLabel";
+import RunButton from "../components/editor/RunButton";
 
 
 function NFAPageContent() {
@@ -106,13 +107,10 @@ function NFAPageContent() {
                         </div>
                         <div className="flex flex-wrap self-center gap-5">
                             {/* Run button to run the NFA with the given input string */}
-                            <button
-                                id="nfaRunBtn"
-                                type="button"
-                                className="flex-none px-8 py-3 bg-gray-700 text-white rounded hover:bg-black transition"
-                            >
-                                Run
-                            </button>
+                            <RunButton
+                                type={"NFA"}
+                            />
+                            
                             {/* My Projects button to open the projects page */}
                             <Link
                                 href="/projects"

--- a/finite-automata-designer/src/app/nfa/page.tsx
+++ b/finite-automata-designer/src/app/nfa/page.tsx
@@ -4,13 +4,13 @@ import Script from 'next/script';
 import { useEffect, useState, Suspense, useRef } from "react";
 // import { useSearchParams } from "next/navigation";
 import { toggle_visiblity } from "../../../public/scripts/canvasUtil/canvasUtil";
+import { Instructions } from "../components/editor/Instructions";
 
 
 function NFAPageContent() {
 
     const [hasMultiCharAlphabet, setHasMultiCharAlphabet] = useState(false);
     const [alphabetInput, setAlphabetInput] = useState("");
-    const [instructionsOpen, setInstructionsOpen] = useState(false);
     const [exportOpen, setExportOpen] = useState(false);
     const [importOpen, setImportOpen] = useState(false);
     // const searchParams = useSearchParams();
@@ -57,43 +57,9 @@ function NFAPageContent() {
                 <Link href="/" className="px-6 py-3 bg-gray-700 text-white rounded hover:bg-black transition">
                     ← Back
                 </Link>
-                <div className="mt-6 pr-4 w-full text-black">
-                    <button
-                        type="button"
-                        onClick={() => setInstructionsOpen(prev => !prev)}
-                        className="flex items-center gap-2 px-4 py-2 bg-gray-700 text-white rounded hover:bg-black transition"
-                    >
-                        Instructions
-                        <svg
-                            className={`h-4 w-4 transition-transform ${instructionsOpen ? "rotate-180" : ""}`}
-                            xmlns="http://www.w3.org/2000/svg"
-                            viewBox="0 0 20 20"
-                            fill="currentColor"
-                        >
-                            <path
-                                fillRule="evenodd"
-                                d="M5.23 7.21a.75.75 0 011.06.02L10 10.939l3.71-3.71a.75.75 0 111.06 1.06l-4.24 4.24a.75.75 0 01-1.06 0L5.25 8.27a.75.75 0 01-.02-1.06z"
-                                clipRule="evenodd"
-                            />
-                        </svg>
-                    </button>
-                    {instructionsOpen && (
-                        <ul className="list-disc text-left mt-3 ml-4 text-sm space-y-1">
-                            <li><p className="font-semibold inline">Add a state: </p>Double-click on the canvas</li>
-                            <li><p className="font-semibold inline">Define start state: </p>Shift + Click empty space on canvas + Drag your desired start state</li>
-                            <li><p className="font-semibold inline">Add an arrow between states: </p>Shift + Click initial state + Drag the mouse to your desired terminal state</li>
-                            <li><p className="font-semibold inline">Add a looped arrow on a state: </p>Shift + Click existing state</li>
-                            <li><p className="font-semibold inline">Curve arrows: </p>Click your desired arrow and drag in the direction you wish to curve it</li>
-                            <li><p className="font-semibold inline">Move anything: </p>Click + Drag it around</li>
-                            <li><p className="font-semibold inline">Delete anything: </p>Click it and press the delete key (not backspace)</li>
-                            <li><p className="font-semibold inline">Make accept state: </p>Double-click an existing state</li>
-                            <li><p className="font-semibold inline">Type onto arrow or state: </p>Click on desired state, then begin typing. Click again anywhere else to submit</li>
-                            <li><p className="font-semibold inline">Type numeric subscript: </p>Put an underscore before the number (ex: &quot;q_0&quot;)</li>
-                            <li><p className="font-semibold inline">Set alphabet: </p>Type a comma-separated list of all the characters you wish to define for your NFA. Press Enter to submit</li>
-                            <li><p className="font-semibold inline">Run NFA: </p>Type an input string containing only the characters from your alphabet. Press Enter to submit</li>
-                        </ul>
-                    )}
-                </div>
+                <Instructions
+                    type={"NFA"}
+                />
             </div>
             {/* Canvas parent div*/}
             <div>

--- a/finite-automata-designer/src/app/nfa/page.tsx
+++ b/finite-automata-designer/src/app/nfa/page.tsx
@@ -14,6 +14,7 @@ import AlphabetInput from "../components/editor/alphabet/AlphabetInput";
 import AlphabetLabel from "../components/editor/alphabet/AlphabetLabel";
 import RunButton from "../components/editor/RunButton";
 import ProjectsButton from "../components/editor/ProjectsButton";
+import ClearCanvasButton from "../components/editor/ClearCanvasButton";
 
 
 function NFAPageContent() {
@@ -114,19 +115,12 @@ function NFAPageContent() {
 
                             {/* My Projects button to open the projects page */}
                             <ProjectsButton />
-                            
+
                         </div>
                     </div>
                     {/* Clear Canvas parent container */}
                     <div>
-                        <div className="mt-4 flex justify-center">
-                            <button
-                                id="clearCanvas"
-                                type="button"
-                                className="bg-gray-700 text-white px-6 py-3 rounded hover:bg-gray-500 transition">
-                                Clear Canvas
-                            </button>
-                        </div>
+                        <ClearCanvasButton />
                     </div>
                 </div>
             </div>

--- a/finite-automata-designer/src/app/nfa/page.tsx
+++ b/finite-automata-designer/src/app/nfa/page.tsx
@@ -4,7 +4,7 @@ import Script from 'next/script';
 import { useEffect, useState, Suspense, useRef } from "react";
 // import { useSearchParams } from "next/navigation";
 import { toggle_visiblity } from "../../../public/scripts/canvasUtil/canvasUtil";
-import { Instructions } from "../components/editor/Instructions";
+import Instructions from "../components/editor/Instructions";
 
 
 function NFAPageContent() {

--- a/finite-automata-designer/src/app/nfa/page.tsx
+++ b/finite-automata-designer/src/app/nfa/page.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState, Suspense, useRef } from "react";
 // import { useSearchParams } from "next/navigation";
 import { toggle_visiblity } from "../../../public/scripts/canvasUtil/canvasUtil";
 import Instructions from "../components/editor/Instructions";
+import AutomataHeader from "../components/editor/AutomataHeader";
 
 
 function NFAPageContent() {
@@ -15,6 +16,8 @@ function NFAPageContent() {
     const [importOpen, setImportOpen] = useState(false);
     // const searchParams = useSearchParams();
     // const id = searchParams?.get("id");
+
+    const title: string = "Non-deterministic Finite Automata";
 
     const exportMenuRef = useRef<HTMLDivElement>(null);
     const importMenuRef = useRef<HTMLDivElement>(null);
@@ -44,12 +47,9 @@ function NFAPageContent() {
     return (
       <main className="min-h-screen bg-blue-100 flex flex-col items-center">
         {/* NFA title at the top */}
-        <h1 className="text-5xl font-bold text-center my-2 text-black ">
-            <span className="drop-shadow-[0_0_1px_rgba(0,0,0,0.7)]">
-                Non-deterministic Finite Automata
-            </span>
-            <span className="h-8 bg-gradient-to-b from-white/30 via-white/10 to-transparent opacity-20 rounded pointer-events-none"></span>
-        </h1>
+        <AutomataHeader
+            title={title}
+        />
         <div className="flex w-full">
             {/* Back Button + Instructions parent div*/}
             <div className="flex-1 flex flex-col items-start h-13 pl-5" >

--- a/finite-automata-designer/src/app/nfa/page.tsx
+++ b/finite-automata-designer/src/app/nfa/page.tsx
@@ -68,6 +68,7 @@ function NFAPageContent() {
                 />
 
             </div>
+            
             {/* Canvas parent div*/}
             <div>
                 <div id="canvasDiv" className="flex flex-col text-black">
@@ -80,15 +81,6 @@ function NFAPageContent() {
                     {/* Importing dropdowns container*/}
                     <ImportContainer />
 
-                    {/*Leave for now in case we turn back the UI for importing and exporting*/}
-
-                    {/* <div className="text-center text-black mt-2">
-                        Export as: <button id='svgExportBtn' type="button" className="cursor-pointer">SVG</button>
-                        {' | '} <button id='latexExportBtn' type="button" className="cursor-pointer">LaTeX</button>
-                        <br />
-                        Import as: <button id='svgImportBtn' type="button" className="cursor-pointer">SVG</button>
-                        {' | '} <button id='latexImportBtn' type="button" className="cursor-pointer">LaTeX</button>
-                    </div> */}
 
                     <ExportTextArea />
 

--- a/finite-automata-designer/src/app/nfa/page.tsx
+++ b/finite-automata-designer/src/app/nfa/page.tsx
@@ -9,6 +9,7 @@ import ImportContainer from "../components/editor/import/ImportContainer";
 import ExportContainer from "../components/editor/export/ExportContainer";
 import ExportTextArea from "../components/editor/export/ExportTextArea";
 import ImportTextArea from "../components/editor/import/ImportTextArea";
+import InputString from "../components/editor/InputString";
 
 
 function NFAPageContent() {
@@ -93,21 +94,8 @@ function NFAPageContent() {
                     <div className="flex flex-col gap-5">
                         <div id='inputDiv' className="flex flex-col self-center w-full max-w-md text-black">
                             {/* Textbox for inputting strings */}
-                            <label htmlFor="inputString" className="block mb-1 text-gray-700 text-xl font-bold">
-                                Input:
-                            </label>
-                            <input
-                                id="inputString"
-                                type="text"
-                                placeholder="Enter a string..."
-                                className="w-full px-4 py-2 border border-gray-400 rounded shadow-sm bg-white focus:outline-none focus:ring-2 focus:ring-blue-400"
-                                // Loose focus after you press enter
-                                onKeyDown={(e) => {
-                                    if (e.key === "Enter") {
-                                        e.currentTarget.blur();
-                                    }
-                                }}
-                            />
+                            <InputString />
+                            
                             <div className="min-h-[3rem]">
                                 {hasMultiCharAlphabet && (
                                     <div className="w-full rounded border border-red-300 bg-red-100 px-3 py-2">

--- a/finite-automata-designer/src/app/nfa/page.tsx
+++ b/finite-automata-designer/src/app/nfa/page.tsx
@@ -62,13 +62,14 @@ function NFAPageContent() {
             <div className="flex-1 flex flex-col items-start h-13 pl-5" >
                 {/* Back Button to return to Home Page */}
                 <BackButton />
-
+                
+                {/* Instructions dropdown */}
                 <Instructions
                     type={"NFA"}
                 />
 
             </div>
-            
+
             {/* Canvas parent div*/}
             <div>
                 <div id="canvasDiv" className="flex flex-col text-black">
@@ -81,9 +82,10 @@ function NFAPageContent() {
                     {/* Importing dropdowns container*/}
                     <ImportContainer />
 
-
+                    {/* Exporting text area */}
                     <ExportTextArea />
 
+                    {/* Importing text area */}
                     <ImportTextArea />
 
                 </div>
@@ -97,10 +99,12 @@ function NFAPageContent() {
                             {/* Textbox for inputting strings */}
                             <InputString />
                             
+                            {/* Alphabet display */}
                             <AlphabetLabel
                                 hasMultiCharAlphabet={hasMultiCharAlphabet}
                             />
                             
+                            {/* Input box for new alphabet */}
                             <AlphabetInput />
                         </div>
                         <div className="flex flex-wrap self-center gap-5">

--- a/finite-automata-designer/src/app/nfa/page.tsx
+++ b/finite-automata-designer/src/app/nfa/page.tsx
@@ -1,25 +1,23 @@
 'use client';
 import Link from "next/link";
 import Script from 'next/script';
-import { useEffect, useState, Suspense, useRef } from "react";
+import { useEffect, useState, Suspense } from "react";
 // import { useSearchParams } from "next/navigation";
-import { toggle_visiblity } from "../../../public/scripts/canvasUtil/canvasUtil";
 import Instructions from "../components/editor/Instructions";
 import AutomataHeader from "../components/editor/AutomataHeader";
 import ImportContainer from "../components/editor/ImportContainer";
+import ExportContainer from "../components/editor/ExportContainer";
 
 
 function NFAPageContent() {
 
     const [hasMultiCharAlphabet, setHasMultiCharAlphabet] = useState(false);
     const [alphabetInput, setAlphabetInput] = useState("");
-    const [exportOpen, setExportOpen] = useState(false);
     // const searchParams = useSearchParams();
     // const id = searchParams?.get("id");
 
     const title: string = "Non-deterministic Finite Automata";
 
-    const exportMenuRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
 
@@ -66,67 +64,7 @@ function NFAPageContent() {
                     {/* Canvas for drawing FSM */}
                     <canvas id="NFACanvas" width={800} height={600} className="rounded-lg border border-gray-400"></canvas>
                     {/* Exporting dropdowns container*/}
-                    <div className="flex gap-2">
-                        <p className="text-lg mt-5">Export as: </p>
-                        <div className="relative inline-block text-left mt-5">
-                            {/* Exporting options parent selector*/}
-                            <button
-                                id="exportMenuBtn"
-                                type="button"
-                                onClick={() => {
-                                    if (exportMenuRef.current) toggle_visiblity(exportMenuRef.current);
-                                    setExportOpen(prev => !prev);
-                                }}
-                                className="flex justify-center gap-x-1.5 rounded-md bg-gray-700 text-white px-2 py-1 text-md hover:bg-black transition"
-                            >
-                                Export Options
-                                <svg
-                                    className={`-mr-1 h-5 w-5 text-gray-400 h-4 w-4 transition-transform ${exportOpen ? "rotate-180" : ""}`}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                    viewBox="0 0 20 20"
-                                    fill="currentColor"
-                                    aria-hidden="true"
-                                >
-                                    <path
-                                        fillRule="evenodd"
-                                        d="M5.23 7.21a.75.75 0 011.06.02L10 10.939l3.71-3.71a.75.75 0 111.06 1.06l-4.24 4.24a.75.75 0 01-1.06 0L5.25 8.27a.75.75 0 01-.02-1.06z"
-                                        clipRule="evenodd"
-                                    />
-                                </svg>
-                            </button>
-
-                            {/* Export Menu options (SVG and LaTeX)*/}
-                            <div
-                                ref={exportMenuRef}
-                                id="exportMenu"
-                                hidden
-                                className="absolute mt-2 w-40 rounded-md bg-gray-700 shadow-lg z-20"
-                            >
-                                <button
-                                    id="svgExportBtn"
-                                    type="button"
-                                    onClick={() => {
-                                        if (exportMenuRef.current) toggle_visiblity(exportMenuRef.current);
-                                        setExportOpen(false);
-                                    }}
-                                    className="block w-full px-4 py-2 text-left text-white hover:bg-gray-600"
-                                >
-                                    SVG
-                                </button>
-                                <button
-                                    id="latexExportBtn"
-                                    type="button"
-                                    onClick={() => {
-                                        if (exportMenuRef.current) toggle_visiblity(exportMenuRef.current);
-                                        setExportOpen(false);
-                                    }}
-                                    className="block w-full px-4 py-2 text-left text-white hover:bg-gray-600"
-                                >
-                                    LaTeX
-                                </button>
-                            </div>
-                        </div>
-                    </div>
+                    <ExportContainer />
                     {/* Importing dropdowns container*/}
                     <ImportContainer />
 

--- a/finite-automata-designer/src/app/nfa/page.tsx
+++ b/finite-automata-designer/src/app/nfa/page.tsx
@@ -10,6 +10,7 @@ import ExportContainer from "../components/editor/export/ExportContainer";
 import ExportTextArea from "../components/editor/export/ExportTextArea";
 import ImportTextArea from "../components/editor/import/ImportTextArea";
 import InputString from "../components/editor/InputString";
+import AlphabetInput from "../components/editor/alphabet/AlphabetInput";
 
 
 function NFAPageContent() {
@@ -110,18 +111,8 @@ function NFAPageContent() {
                             <label id="alphabetLabel" htmlFor="alphabet" className="block mb-1 text-gray-700 text-xl font-bold">
                                 Alphabet: {"{0,1}"}
                             </label>
-                            <input
-                                id="alphabet"
-                                type="text"
-                                placeholder="Enter an alphabet..."
-                                className="w-full px-4 py-2 border border-gray-400 rounded shadow-sm bg-white focus:outline-none focus:ring-2 focus:ring-blue-400"
-                                // Loose focus after you press enter
-                                onKeyDown={(e) => {
-                                    if (e.key === "Enter") {
-                                        e.currentTarget.blur();
-                                    }
-                                }}
-                            />
+                            
+                            <AlphabetInput />
                         </div>
                         <div className="flex flex-wrap self-center gap-5">
                             {/* Run button to run the NFA with the given input string */}

--- a/finite-automata-designer/src/app/nfa/page.tsx
+++ b/finite-automata-designer/src/app/nfa/page.tsx
@@ -7,6 +7,7 @@ import Instructions from "../components/editor/Instructions";
 import AutomataHeader from "../components/editor/AutomataHeader";
 import ImportContainer from "../components/editor/import/ImportContainer";
 import ExportContainer from "../components/editor/export/ExportContainer";
+import ExportTextArea from "../components/editor/export/ExportTextArea";
 
 
 function NFAPageContent() {
@@ -77,19 +78,9 @@ function NFAPageContent() {
                         Import as: <button id='svgImportBtn' type="button" className="cursor-pointer">SVG</button>
                         {' | '} <button id='latexImportBtn' type="button" className="cursor-pointer">LaTeX</button>
                     </div> */}
-                    <div id="exportOutputContainer" hidden className="text-center">
-                        <textarea
-                        disabled
-                        tabIndex={-1}
-                        id="output"
-                        className="w-full h-24 mt-2 border border-gray-400 rounded text-black bg-white select-none"
-                        placeholder="Export will appear here...">
-                        </textarea>
-                        <div className="flex gap-4 justify-center text-black">
-                            <button id='hideOutput' type="button" className="cursor-pointer text-center text-decoration underline">Hide Export Output</button>
-                            <button id='copyOutput' type="button" className="cursor-pointer text-center text-decoration underline">Copy Output</button>
-                        </div>
-                    </div>
+
+                    <ExportTextArea />
+
                     <div id="importInputContainer" hidden className="text-center">
                         <textarea
                         tabIndex={-1}

--- a/finite-automata-designer/src/app/nfa/page.tsx
+++ b/finite-automata-designer/src/app/nfa/page.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState, Suspense, useRef } from "react";
 import { toggle_visiblity } from "../../../public/scripts/canvasUtil/canvasUtil";
 import Instructions from "../components/editor/Instructions";
 import AutomataHeader from "../components/editor/AutomataHeader";
+import ImportContainer from "../components/editor/ImportContainer";
 
 
 function NFAPageContent() {
@@ -13,14 +14,12 @@ function NFAPageContent() {
     const [hasMultiCharAlphabet, setHasMultiCharAlphabet] = useState(false);
     const [alphabetInput, setAlphabetInput] = useState("");
     const [exportOpen, setExportOpen] = useState(false);
-    const [importOpen, setImportOpen] = useState(false);
     // const searchParams = useSearchParams();
     // const id = searchParams?.get("id");
 
     const title: string = "Non-deterministic Finite Automata";
 
     const exportMenuRef = useRef<HTMLDivElement>(null);
-    const importMenuRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
 
@@ -129,75 +128,7 @@ function NFAPageContent() {
                         </div>
                     </div>
                     {/* Importing dropdowns container*/}
-                    <div className="flex gap-2 mt-2">
-                        <p className="text-lg">Import as: </p>
-                        <div className="flex gap-2">
-                            {/* Importing options parent selector*/}
-                            <div className="relative inline-block text-left">
-                                <button
-                                    id="importMenuBtn"
-                                    type="button"
-                                    onClick={() => {
-                                        if (importMenuRef.current) toggle_visiblity(importMenuRef.current);
-                                        setImportOpen(prev => !prev);
-                                    }}
-                                    className="flex justify-center gap-x-1.5 rounded-md bg-gray-700 text-white px-2 py-1 text-md hover:bg-black transition"
-                                >
-                                    Import Options
-                                    <svg
-                                        className={`-mr-1 h-5 w-5 text-gray-400 h-4 w-4 transition-transform ${importOpen ? "rotate-180" : ""}`}
-                                        xmlns="http://www.w3.org/2000/svg"
-                                        viewBox="0 0 20 20"
-                                        fill="currentColor"
-                                        aria-hidden="true"
-                                    >
-                                        <path
-                                            fillRule="evenodd"
-                                            d="M5.23 7.21a.75.75 0 011.06.02L10 10.939l3.71-3.71a.75.75 0 111.06 1.06l-4.24 4.24a.75.75 0 01-1.06 0L5.25 8.27a.75.75 0 01-.02-1.06z"
-                                            clipRule="evenodd"
-                                        />
-                                    </svg>
-                                </button>
-                                {/* Import Menu options (SVG and LaTeX)*/}
-                                <div
-                                    ref={importMenuRef}
-                                    id="importMenu"
-                                    hidden
-                                    className="absolute mt-2 w-40 rounded-md bg-gray-700 shadow-lg z-20"
-                                >
-                                    <button
-                                    id="svgImportBtn"
-                                    type="button"
-                                    onClick={() => {
-                                        if (importMenuRef.current) toggle_visiblity(importMenuRef.current);
-                                        setImportOpen(false);
-                                    }}
-                                    className="block w-full px-4 py-2 text-left text-white hover:bg-gray-600"
-                                    >
-                                    Import as SVG
-                                    </button>
-                                    <button
-                                    id="latexImportBtn"
-                                    type="button"
-                                    onClick={() => {
-                                        if (importMenuRef.current) toggle_visiblity(importMenuRef.current);
-                                        setImportOpen(false);
-                                    }}
-                                    className="block w-full px-4 py-2 text-left text-white hover:bg-gray-600"
-                                    >
-                                    Import as LaTeX
-                                    </button>
-                                </div>
-                            </div>
-                            <button
-                            id="confirmImport"
-                            className="flex justify-center gap-x-1.5 rounded-md bg-gray-700 text-white px-2 py-1 text-md hover:bg-black transition"
-                            hidden
-                            >
-                                Draw Import
-                            </button>
-                        </div>
-                    </div>
+                    <ImportContainer />
 
                     {/*Leave for now in case we turn back the UI for importing and exporting*/}
 

--- a/finite-automata-designer/src/app/nfa/page.tsx
+++ b/finite-automata-designer/src/app/nfa/page.tsx
@@ -11,6 +11,7 @@ import ExportTextArea from "../components/editor/export/ExportTextArea";
 import ImportTextArea from "../components/editor/import/ImportTextArea";
 import InputString from "../components/editor/InputString";
 import AlphabetInput from "../components/editor/alphabet/AlphabetInput";
+import AlphabetLabel from "../components/editor/alphabet/AlphabetLabel";
 
 
 function NFAPageContent() {
@@ -97,20 +98,9 @@ function NFAPageContent() {
                             {/* Textbox for inputting strings */}
                             <InputString />
                             
-                            <div className="min-h-[3rem]">
-                                {hasMultiCharAlphabet && (
-                                    <div className="w-full rounded border border-red-300 bg-red-100 px-3 py-2">
-                                        <p className="text-sm text-red-700 font-semibold">
-                                            Multi-character element detected in alphabet. Please separate elements
-                                            in your input string with commas or spaces.
-                                        </p>
-                                    </div>
-                                )}
-                            </div>
-                            {/* Textbox for inputting the alphabet */}
-                            <label id="alphabetLabel" htmlFor="alphabet" className="block mb-1 text-gray-700 text-xl font-bold">
-                                Alphabet: {"{0,1}"}
-                            </label>
+                            <AlphabetLabel
+                                hasMultiCharAlphabet={hasMultiCharAlphabet}
+                            />
                             
                             <AlphabetInput />
                         </div>

--- a/finite-automata-designer/src/app/nfa/page.tsx
+++ b/finite-automata-designer/src/app/nfa/page.tsx
@@ -13,6 +13,7 @@ import InputString from "../components/editor/InputString";
 import AlphabetInput from "../components/editor/alphabet/AlphabetInput";
 import AlphabetLabel from "../components/editor/alphabet/AlphabetLabel";
 import RunButton from "../components/editor/RunButton";
+import ProjectsButton from "../components/editor/ProjectsButton";
 
 
 function NFAPageContent() {
@@ -110,14 +111,10 @@ function NFAPageContent() {
                             <RunButton
                                 type={"NFA"}
                             />
-                            
+
                             {/* My Projects button to open the projects page */}
-                            <Link
-                                href="/projects"
-                                className="flex-none px-8 py-3 bg-gray-700 text-white rounded hover:bg-black transition"
-                            >
-                                My Projects
-                            </Link>
+                            <ProjectsButton />
+                            
                         </div>
                     </div>
                     {/* Clear Canvas parent container */}

--- a/finite-automata-designer/src/app/projects/page.tsx
+++ b/finite-automata-designer/src/app/projects/page.tsx
@@ -98,9 +98,7 @@ export default function AutomataPage() {
 
             { deletingProject &&
                 <DeleteProjectModal 
-                    id={deletingProject.id}
                     name={deletingProject.name}
-                    description={deletingProject.description}
                     onDelete={() => handleDelete(deletingProject.id)}
                     onCancel={() => setDeletingProject(null)}
                 />

--- a/finite-automata-designer/src/app/projects/page.tsx
+++ b/finite-automata-designer/src/app/projects/page.tsx
@@ -5,10 +5,13 @@ import { useRouter } from "next/navigation";
 import { FiniteAutomaton } from "@/lib/shared/types";
 import { getUserAutomata } from "@/lib/automata/queries";
 import ProjectCard from "../components/projects/ProjectCard";
+import { deleteAutomaton } from "@/lib/automata/mutations";
 
 export default function AutomataPage() {
   const [machines, setMachines] = useState<FiniteAutomaton[]>([]);
   const [loading, setLoading] = useState(true);
+  const [deletingProject, setDeletingProject] = useState<FiniteAutomaton | null>(null);
+
   const router = useRouter();
 
   useEffect(() => {
@@ -29,6 +32,22 @@ export default function AutomataPage() {
 
     loadMachines();
   }, [router]);
+
+  const handleDelete = async (automatonId: string) => {
+    try{
+      await deleteAutomaton(automatonId);
+
+      // Remove the deleted automaton from the machines array
+      setMachines((prev) => prev.filter(project => project.id !== automatonId));
+    }
+    catch(error){
+      console.error(error);
+      alert("Failed to delete selected project: " + error);
+    }
+    finally{
+      setDeletingProject(null);
+    }
+  };
 
   if (loading) {
     return (
@@ -69,11 +88,13 @@ export default function AutomataPage() {
                                 name={machine.name}
                                 description={machine.description}
                                 type={machine.type}
+                                onDelete={() => setDeletingProject(machine)}
                             />
                         ))}
                     </div>
                 )}
             </div>
+
         </main>
     );
 }

--- a/finite-automata-designer/src/app/projects/page.tsx
+++ b/finite-automata-designer/src/app/projects/page.tsx
@@ -3,8 +3,8 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { createClient } from "@/lib/supabase/client";
 import { FiniteAutomaton } from "@/lib/shared/types";
+import { getUserAutomata } from "@/lib/automata/queries";
 
 export default function AutomataPage() {
   const [machines, setMachines] = useState<FiniteAutomaton[]>([]);
@@ -13,28 +13,18 @@ export default function AutomataPage() {
 
   useEffect(() => {
     async function loadMachines() {
-      const supabase = createClient();
-
-      const { data: { user }, error: userError } = await supabase.auth.getUser();
-
-      if (userError || !user) {
-        router.replace("/login");
-        return;
+      try{
+        const automata = await getUserAutomata();
+        setMachines(automata || []);
       }
-
-      const { data, error } = await supabase
-        .from("finite_automata")
-        .select("*")
-        .eq("user_id", user.id);
-
-      if (error) {
+      catch(error){
         console.error(error);
-        setLoading(false);
-        return;
+        alert("Failed to retrieve user's projects: " + error);
       }
-
-      setMachines(data || []);
-      setLoading(false);
+      finally{
+        setLoading(false);
+      }
+      
     }
 
     loadMachines();

--- a/finite-automata-designer/src/app/projects/page.tsx
+++ b/finite-automata-designer/src/app/projects/page.tsx
@@ -4,15 +4,7 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/client";
-
-interface FiniteAutomaton {
-  id: string;
-  user_id: string;
-  name: string;
-  type: string;
-  automaton: unknown;
-  created_at?: string;
-}
+import { FiniteAutomaton } from "@/lib/shared/types";
 
 export default function AutomataPage() {
   const [machines, setMachines] = useState<FiniteAutomaton[]>([]);

--- a/finite-automata-designer/src/app/projects/page.tsx
+++ b/finite-automata-designer/src/app/projects/page.tsx
@@ -7,6 +7,7 @@ import { getUserAutomata } from "@/lib/automata/queries";
 import ProjectCard from "../components/projects/ProjectCard";
 import { deleteAutomaton, editAutomaton } from "@/lib/automata/mutations";
 import { DeleteProjectModal } from "../components/projects/DeleteProjectModal";
+import { EditProjectModal } from "../components/projects/EditProjectModal";
 
 export default function AutomataPage() {
   const [machines, setMachines] = useState<FiniteAutomaton[]>([]);
@@ -124,6 +125,16 @@ export default function AutomataPage() {
                     name={deletingProject.name}
                     onDelete={() => handleDelete(deletingProject.id)}
                     onClose={() => setDeletingProject(null)}
+                />
+            }
+
+            { editingProject &&
+                <EditProjectModal 
+                    id={editingProject.id}
+                    initialName={editingProject.name}
+                    initialDescription={editingProject.description}
+                    onSave={handleEdit}
+                    onClose={() => setEditingProject(null)}
                 />
             }
         </main>

--- a/finite-automata-designer/src/app/projects/page.tsx
+++ b/finite-automata-designer/src/app/projects/page.tsx
@@ -6,6 +6,7 @@ import { FiniteAutomaton } from "@/lib/shared/types";
 import { getUserAutomata } from "@/lib/automata/queries";
 import ProjectCard from "../components/projects/ProjectCard";
 import { deleteAutomaton } from "@/lib/automata/mutations";
+import { DeleteProjectModal } from "../components/projects/DeleteProjectModal";
 
 export default function AutomataPage() {
   const [machines, setMachines] = useState<FiniteAutomaton[]>([]);
@@ -36,7 +37,7 @@ export default function AutomataPage() {
   const handleDelete = async (automatonId: string) => {
     try{
       await deleteAutomaton(automatonId);
-
+      
       // Remove the deleted automaton from the machines array
       setMachines((prev) => prev.filter(project => project.id !== automatonId));
     }
@@ -95,6 +96,15 @@ export default function AutomataPage() {
                 )}
             </div>
 
+            { deletingProject &&
+                <DeleteProjectModal 
+                    id={deletingProject.id}
+                    name={deletingProject.name}
+                    description={deletingProject.description}
+                    onDelete={() => handleDelete(deletingProject.id)}
+                    onCancel={() => setDeletingProject(null)}
+                />
+            }
         </main>
     );
 }

--- a/finite-automata-designer/src/app/projects/page.tsx
+++ b/finite-automata-designer/src/app/projects/page.tsx
@@ -62,6 +62,19 @@ export default function AutomataPage() {
         (name === "") ? null : name,
         (description === "") ? null : description,
       );
+      
+      setMachines((prev) => 
+        prev.map((project) =>
+          project.id === automatonId
+            ? {
+                ...project,
+                name: name === "" ? null : name,
+                description: description === "" ? null: description,
+              } as FiniteAutomaton
+            : project
+        )
+      );
+
       alert("Saved edit successfully!");
     }
     catch(error){

--- a/finite-automata-designer/src/app/projects/page.tsx
+++ b/finite-automata-designer/src/app/projects/page.tsx
@@ -57,7 +57,7 @@ export default function AutomataPage() {
   const handleEdit = async (automatonId: string, name: string, description: string) => {
     try{
 
-      await editAutomaton(
+      const editedAutomaton = await editAutomaton(
         automatonId, 
         (name === "") ? null : name,
         (description === "") ? null : description,
@@ -66,11 +66,7 @@ export default function AutomataPage() {
       setMachines((prev) => 
         prev.map((project) =>
           project.id === automatonId
-            ? {
-                ...project,
-                name: name === "" ? null : name,
-                description: description === "" ? null: description,
-              } as FiniteAutomaton
+            ? editedAutomaton
             : project
         )
       );

--- a/finite-automata-designer/src/app/projects/page.tsx
+++ b/finite-automata-designer/src/app/projects/page.tsx
@@ -5,13 +5,14 @@ import { useRouter } from "next/navigation";
 import { FiniteAutomaton } from "@/lib/shared/types";
 import { getUserAutomata } from "@/lib/automata/queries";
 import ProjectCard from "../components/projects/ProjectCard";
-import { deleteAutomaton } from "@/lib/automata/mutations";
+import { deleteAutomaton, editAutomaton } from "@/lib/automata/mutations";
 import { DeleteProjectModal } from "../components/projects/DeleteProjectModal";
 
 export default function AutomataPage() {
   const [machines, setMachines] = useState<FiniteAutomaton[]>([]);
   const [loading, setLoading] = useState(true);
   const [deletingProject, setDeletingProject] = useState<FiniteAutomaton | null>(null);
+  const [editingProject, setEditingProject] = useState<FiniteAutomaton | null>(null);
 
   const router = useRouter();
 
@@ -40,6 +41,8 @@ export default function AutomataPage() {
       
       // Remove the deleted automaton from the machines array
       setMachines((prev) => prev.filter(project => project.id !== automatonId));
+
+      alert("Deleted project successfully!");
     }
     catch(error){
       console.error(error);
@@ -47,6 +50,25 @@ export default function AutomataPage() {
     }
     finally{
       setDeletingProject(null);
+    }
+  };
+
+  const handleEdit = async (automatonId: string, name: string, description: string) => {
+    try{
+
+      await editAutomaton(
+        automatonId, 
+        (name === "") ? null : name,
+        (description === "") ? null : description,
+      );
+      alert("Saved edit successfully!");
+    }
+    catch(error){
+      console.error(error);
+      alert("Failed to save edit: " + error);
+    }
+    finally{
+      setEditingProject(null);
     }
   };
 
@@ -90,6 +112,7 @@ export default function AutomataPage() {
                                 description={machine.description}
                                 type={machine.type}
                                 onDelete={() => setDeletingProject(machine)}
+                                onEdit={() => setEditingProject(machine)}
                             />
                         ))}
                     </div>
@@ -100,7 +123,7 @@ export default function AutomataPage() {
                 <DeleteProjectModal 
                     name={deletingProject.name}
                     onDelete={() => handleDelete(deletingProject.id)}
-                    onCancel={() => setDeletingProject(null)}
+                    onClose={() => setDeletingProject(null)}
                 />
             }
         </main>

--- a/finite-automata-designer/src/app/projects/page.tsx
+++ b/finite-automata-designer/src/app/projects/page.tsx
@@ -2,9 +2,9 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import Link from "next/link";
 import { FiniteAutomaton } from "@/lib/shared/types";
 import { getUserAutomata } from "@/lib/automata/queries";
+import ProjectCard from "../components/projects/ProjectCard";
 
 export default function AutomataPage() {
   const [machines, setMachines] = useState<FiniteAutomaton[]>([]);
@@ -42,20 +42,38 @@ export default function AutomataPage() {
   }
 
   return (
-    <main className="min-h-screen bg-blue-100 p-10 text-black">
-      <h1 className="text-4xl font-bold mb-6 text-center">My Projects</h1>
+        <main className="min-h-screen bg-blue-100 p-6 md:p-10">
+            <div className="max-w-6xl mx-auto">
+                <div className="flex items-center justify-between mb-8">
+                    <h1 className="text-4xl font-bold text-gray-800">
+                        My Projects
+                    </h1>
+                </div>
 
-      <div className="flex flex-col gap-4">
-        {machines.map((machine) => (
-          <Link
-            key={machine.id}
-            href={`/dfa?id=${machine.id}`}
-            className="bg-gray-700 text-white px-4 py-3 rounded hover:bg-black transition"
-          >
-            Automaton {machine.id}
-          </Link>
-        ))}
-      </div>
-    </main>
-  );
+                {machines.length === 0 ? (
+                    <div className="bg-white rounded-xl shadow p-10 text-center">
+                        <h2 className="text-2xl font-semibold text-gray-700 mb-2">
+                            No Projects Yet
+                        </h2>
+
+                        <p className="text-gray-500">
+                            Create your first automaton to get started.
+                        </p>
+                    </div>
+                ) : (
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                        {machines.map((machine) => (
+                            <ProjectCard
+                                key={machine.id}
+                                id={machine.id}
+                                name={machine.name}
+                                description={machine.description}
+                                type={machine.type}
+                            />
+                        ))}
+                    </div>
+                )}
+            </div>
+        </main>
+    );
 }

--- a/finite-automata-designer/src/lib/automata/mutations.ts
+++ b/finite-automata-designer/src/lib/automata/mutations.ts
@@ -75,3 +75,26 @@ export async function deleteAutomaton(automatonId: string){
     return data;
 }
 
+export async function editAutomaton(automatonId: string, name: string | null, description: string | null){
+    const supabase = createClient();
+
+    const { data: { user } } = await supabase.auth.getUser();
+
+    if(!user){
+        throw new Error("User is not authenticated.");
+    }
+
+    const { data, error } = await supabase
+        .from("finite_automata")
+        .update({
+            name: name,
+            description: description,
+        })
+        .eq("id",automatonId);
+
+    if(error){
+        throw error;
+    }
+
+    return data;
+}

--- a/finite-automata-designer/src/lib/automata/mutations.ts
+++ b/finite-automata-designer/src/lib/automata/mutations.ts
@@ -1,5 +1,5 @@
 import { SerializedDFA } from "../dfa/types";
-import { CreateAutomaton } from "../shared/types";
+import { CreateAutomaton, FiniteAutomaton } from "../shared/types";
 import { createClient } from "../supabase/client";
 
 export async function saveAutomaton(serializedDFA: SerializedDFA, name: string | null, description: string | null){
@@ -8,8 +8,7 @@ export async function saveAutomaton(serializedDFA: SerializedDFA, name: string |
     const { data: { user } } = await supabase.auth.getUser();
 
     if(!user){
-        alert("You must be logged in to save.");
-        return;
+        throw new Error("User is not authenticated.");
     }
 
     const { data, error } = await supabase
@@ -24,10 +23,10 @@ export async function saveAutomaton(serializedDFA: SerializedDFA, name: string |
         .select()
         .single();
 
-        if(error){
-            throw error;
-        }
+    if(error || !data){
+        throw error;
+    }
 
-        return data;
+    return data as FiniteAutomaton;
     
 }

--- a/finite-automata-designer/src/lib/automata/mutations.ts
+++ b/finite-automata-designer/src/lib/automata/mutations.ts
@@ -1,6 +1,6 @@
-import { SerializedDFA } from "./dfa/types";
-import { CreateAutomaton } from "./shared/types";
-import { createClient } from "./supabase/client";
+import { SerializedDFA } from "../dfa/types";
+import { CreateAutomaton } from "../shared/types";
+import { createClient } from "../supabase/client";
 
 export async function saveAutomaton(serializedDFA: SerializedDFA, name: string | null, description: string | null){
     const supabase = createClient();

--- a/finite-automata-designer/src/lib/automata/mutations.ts
+++ b/finite-automata-designer/src/lib/automata/mutations.ts
@@ -90,11 +90,13 @@ export async function editAutomaton(automatonId: string, name: string | null, de
             name: name,
             description: description,
         })
-        .eq("id",automatonId);
+        .eq("id",automatonId)
+        .select()
+        .single();
 
     if(error){
         throw error;
     }
 
-    return data;
+    return data as FiniteAutomaton;
 }

--- a/finite-automata-designer/src/lib/automata/mutations.ts
+++ b/finite-automata-designer/src/lib/automata/mutations.ts
@@ -37,8 +37,7 @@ export async function updateAutomaton(automatonId: string, serializedDFA: Serial
     const { data: { user } } = await supabase.auth.getUser();
 
     if(!user){
-        alert("You must be logged in to save.");
-        return;
+        throw new Error("User is not authenticated.");
     }
 
     const { data, error } = await supabase
@@ -54,3 +53,25 @@ export async function updateAutomaton(automatonId: string, serializedDFA: Serial
 
     return data;
 }
+
+export async function deleteAutomaton(automatonId: string){
+    const supabase = createClient();
+
+    const { data: { user } } = await supabase.auth.getUser();
+
+    if(!user){
+        throw new Error("User is not authenticated.");
+    }
+
+    const { data, error } = await supabase
+        .from("finite_automata")
+        .delete()
+        .eq("id", automatonId);
+
+    if(error){
+        throw error;
+    }
+
+    return data;
+}
+

--- a/finite-automata-designer/src/lib/automata/mutations.ts
+++ b/finite-automata-designer/src/lib/automata/mutations.ts
@@ -30,3 +30,27 @@ export async function saveAutomaton(serializedDFA: SerializedDFA, name: string |
     return data as FiniteAutomaton;
     
 }
+
+export async function updateAutomaton(automatonId: string, serializedDFA: SerializedDFA){
+    const supabase = createClient();
+
+    const { data: { user } } = await supabase.auth.getUser();
+
+    if(!user){
+        alert("You must be logged in to save.");
+        return;
+    }
+
+    const { data, error } = await supabase
+        .from("finite_automata")
+        .update({
+            automaton: serializedDFA,
+        })
+        .eq("id", automatonId);
+
+    if(error){
+        throw error;
+    }
+
+    return data;
+}

--- a/finite-automata-designer/src/lib/automata/queries.ts
+++ b/finite-automata-designer/src/lib/automata/queries.ts
@@ -16,11 +16,34 @@ export async function getUserAutomata(){
         .eq("user_id", user.id);
 
 
-    if (error) {
+    if (!data || error) {
         console.error(error);
         throw new Error("There was an error fetching the user's projects.");
     }
 
     return data as FiniteAutomaton[];
     
+}
+
+export async function getAutomaton(automatonId: string){
+    const supabase = createClient();
+
+    const { data: { user }, error: userError} = await supabase.auth.getUser();
+
+    if(!user || userError){
+        throw new Error("User is not authenticated.");
+    }
+
+    const { data, error } = await supabase
+        .from("finite_automata")
+        .select("*")
+        .eq("id", automatonId)
+        .single();
+
+    if(!data || error){
+        console.error(error);
+        throw new Error("Failed to fetch selected automaton.");
+    }
+
+    return data as FiniteAutomaton;
 }

--- a/finite-automata-designer/src/lib/automata/queries.ts
+++ b/finite-automata-designer/src/lib/automata/queries.ts
@@ -1,0 +1,26 @@
+import { createClient } from "../supabase/client";
+import { FiniteAutomaton } from "../shared/types";
+
+export async function getUserAutomata(){
+    const supabase = createClient();
+    
+    const { data: { user }, error: userError } = await supabase.auth.getUser();
+
+    if (userError || !user) {
+        throw new Error("User is not authenticated.");
+    }
+
+    const { data, error } = await supabase
+        .from("finite_automata")
+        .select("*")
+        .eq("user_id", user.id);
+
+
+    if (error) {
+        console.error(error);
+        throw new Error("There was an error fetching the user's projects.");
+    }
+
+    return data as FiniteAutomaton[];
+    
+}

--- a/finite-automata-designer/src/lib/saveAutomaton.ts
+++ b/finite-automata-designer/src/lib/saveAutomaton.ts
@@ -1,16 +1,17 @@
+import { SerializedDFA } from "./dfa/types";
+import { CreateAutomaton } from "./shared/types";
 import { createClient } from "./supabase/client";
 
-export async function saveAutomaton(userId: string, serializedDFA: unknown){
+export async function saveAutomaton(userId: string, serializedDFA: SerializedDFA){
     const supabase = createClient();
 
     const { data, error } = await supabase
         .from("finite_automata")
         .insert({
             user_id: userId,
-            name: "Untitled DFA",
             type: "DFA",
             automaton: serializedDFA
-        })
+        } as CreateAutomaton)
         .select()
         .single();
 

--- a/finite-automata-designer/src/lib/saveAutomaton.ts
+++ b/finite-automata-designer/src/lib/saveAutomaton.ts
@@ -2,13 +2,22 @@ import { SerializedDFA } from "./dfa/types";
 import { CreateAutomaton } from "./shared/types";
 import { createClient } from "./supabase/client";
 
-export async function saveAutomaton(userId: string, serializedDFA: SerializedDFA){
+export async function saveAutomaton(serializedDFA: SerializedDFA, name: string | null, description: string | null){
     const supabase = createClient();
+
+    const { data: { user } } = await supabase.auth.getUser();
+
+    if(!user){
+        alert("You must be logged in to save.");
+        return;
+    }
 
     const { data, error } = await supabase
         .from("finite_automata")
         .insert({
-            user_id: userId,
+            user_id: user.id,
+            name: name,
+            description: description,
             type: "DFA",
             automaton: serializedDFA
         } as CreateAutomaton)

--- a/finite-automata-designer/src/lib/shared/types.ts
+++ b/finite-automata-designer/src/lib/shared/types.ts
@@ -44,8 +44,8 @@ export interface FiniteAutomaton {
 
 export interface CreateAutomaton {
     user_id: string;
-    name?: string;
-    description?: string;
+    name?: string | null;
+    description?: string | null;
     type: "DFA" | "NFA";
     automaton: SerializedDFA;
 }

--- a/finite-automata-designer/src/lib/shared/types.ts
+++ b/finite-automata-designer/src/lib/shared/types.ts
@@ -41,3 +41,11 @@ export interface FiniteAutomaton {
     created_at: string;
     updated_at: string;
 }
+
+export interface CreateAutomaton {
+    user_id: string;
+    name?: string;
+    description?: string;
+    type: "DFA" | "NFA";
+    automaton: SerializedDFA;
+}

--- a/finite-automata-designer/src/lib/shared/types.ts
+++ b/finite-automata-designer/src/lib/shared/types.ts
@@ -1,3 +1,5 @@
+import { SerializedDFA } from "../dfa/types";
+
 export type SerializedCircle = {
     id: string;
     x: number;
@@ -27,4 +29,15 @@ export type SerializedEntryArrow = {
     deltaX?: number;
     deltaY?: number;
     startPoint?: {x: number, y: number};
+}
+
+export interface FiniteAutomaton {
+    id: string;
+    user_id: string;
+    name: string;
+    description: string | null;
+    type: "DFA" | "NFA";
+    automaton: SerializedDFA;
+    created_at: string;
+    updated_at: string;
 }


### PR DESCRIPTION
### Objective: Refactor duplicate code from the DFA and NFA pages into reusable components to enable further scalability.
- [x] AlphabetInput - the input text box for setting a new alphabet
- [x] AlphabetLabel - the display for the current alphabet for the FA
- [x] ExportContainer - the export button and it's corresponding dropdown
- [x] ExportTextArea - the textarea that contains the exported SVG/LaTeX code
- [x] ImportContainer - the import button and it's corresponding dropdown
- [x] ImportTextArea - the textarea that contains the imported SVG/LaTeX code
- [x] AutomataHeader - the header and description of the FA
- [x] BackButton - the button to return to the homepage
- [x] ClearCanvasButton - the button to fully erase the canvas
- [x] InputString - the input text box for entering a string for the FA to parse
- [x] Instructions - the dropdown for the instructions on how to use the FA designer
- [x] ProjectsButton - the button that will redirect you to the Projects page
- [x] RunButton - the button that will run the input string that you have entered
- [x] SaveActions - the button(s) to save the current DFA or save the existing DFA as a new project

### Issues
- The buttons on the right side of the DFA and NFA page could be aligned better

### Future Additions/Refactors
- There are a lot of similarities between the DFA and NFA pages. So, we can create an abstraction here and make a component for the page itself. We will implement this after the CRUD functionality is implemented for NFAs
- Potentially move the logic for existing DFAs back into the original DFA page to keep things more concise (we will revert to using the useSearchParams hook again instead of the useParams hook)