### PR TITLE
Fix: NFA Input String Parsing For Multi-Character Alphabets

### DIFF
--- a/finite-automata-designer/src/lib/input/InputStringLexer.ts
+++ b/finite-automata-designer/src/lib/input/InputStringLexer.ts
@@ -97,27 +97,27 @@ export function parseInputString(
         
     }
 
-    const notDefined: Array<string> = [];
+    const notDefined: Set<string> = new Set();
 
     // Validate that each token is in the alphabet
     for (const token of tokens) {
         // If a token is not in the alphabet, return an error
         if (!alphabet.has(token)) {
-            notDefined.push(token);
+            notDefined.add(token);
         }
     }
 
 
-    if(notDefined.length == 1){
+    if(notDefined.size == 1){
         return {
                 success: false,
-                error: `Symbol '${notDefined[0]}' is not in the alphabet. This input is invalid.`,
+                error: `Symbol ${setToString(notDefined)} is not in the alphabet. This input is invalid. Please check if you used any unnecessary spaces or commas.`,
             };
     }
-    else if(notDefined.length > 1){
+    else if(notDefined.size > 1){
         return {
                 success: false,
-                error: `Symbols '${notDefined.toString()}' are not in the alphabet. This input is invalid.`,
+                error: `Symbols ${setToString(notDefined)} are not in the alphabet. This input is invalid. Please check if you used any unnecessary spaces or commas.`,
             };
     }
     else{
@@ -125,4 +125,14 @@ export function parseInputString(
         return { success: true, tokens };
     }
     
+}
+
+function setToString(set: Set<string>){
+    let ret = "";
+    
+    for(const str of set){
+        ret += "\"" + str + "\",";
+    }
+    
+    return ret.slice(0,-1);
 }

--- a/finite-automata-designer/src/lib/nfa/nfaAlgo.ts
+++ b/finite-automata-designer/src/lib/nfa/nfaAlgo.ts
@@ -130,15 +130,6 @@ export function nfaAlgo(input: string){
     return false;
   }
 
-  // First, we make sure the input string is legal. If it contains
-  // characters not defined in the alphabet, then we return false immediately.
-  for(const char of input){
-    if(!nfaTransitionSymbols.has(char)){
-      alert("Input contains \'" + char + "\', which is not in the alphabet");
-      return false;
-    }
-  }
-
   // This will contain the pointers that will be used in the next iteration
   // of the NFA algorithm.
   const nextPointers: Set<Circle> = new Set();  


### PR DESCRIPTION
### Objective: Resolve Issue #46 
- When tackling multi-character alphabets, we implemented a lexer and validator to parse the strings correctly.
- However, we never overhauled the old input string parser in the nfaAlgo function, which still parsed all input strings character-by-character, which absolutely does not work when dealing with multi-character alphabets.
- So, the solution was simple: delete that old code. Now, it works as intended.
- Bonus: I made the error messages for the input string lexer to be a bit more informative and look a little nicer.