### PR TITLE
Fix: Alphabet Label And Restore Editor State Across Navigation

### DIFF
--- a/finite-automata-designer/public/scripts/canvasUtil/fsmCanvas.ts
+++ b/finite-automata-designer/public/scripts/canvasUtil/fsmCanvas.ts
@@ -59,14 +59,21 @@ export interface FsmCanvasConfig {
 
 // Empties the automaton and wipes the canvas.
 // Returns false when no 2d context is available.
-export function clearAutomaton(canvas: HTMLCanvasElement | null): boolean {
+export function clearAutomaton(
+  canvas: HTMLCanvasElement | null,
+  draw?: () => void,
+): boolean {
   if (canvas) {
     const ctx = canvas.getContext('2d');
     if (ctx) {
       arrows.length = 0;
       circles.length = 0;
       setStartState(null);
-      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      if (draw) {
+        draw();
+      } else {
+          ctx.clearRect(0, 0, canvas.width, canvas.height);
+      }
       return true;
     }
   }

--- a/finite-automata-designer/public/scripts/canvasUtil/fsmCanvas.ts
+++ b/finite-automata-designer/public/scripts/canvasUtil/fsmCanvas.ts
@@ -663,6 +663,12 @@ export function initFsmCanvas(config: FsmCanvasConfig) {
         });
       }
 
+      if(alphabetLabel){
+        updateAlphabetLabel(alphabetLabel);
+        console.log("Dispatching alphabet update...");
+        config.dispatchAlphabetUpdated();
+      }
+
       if (alphabetInput) {
         alphabetInput.addEventListener("keydown", (event) => {
           // If the "Enter" key is pressed on the alphabet input
@@ -679,13 +685,14 @@ export function initFsmCanvas(config: FsmCanvasConfig) {
 
             config.setAlphabet(new Set(normalized));
 
+            updateAlphabetLabel(alphabetLabel);
+
             config.dispatchAlphabetUpdated();
 
             console.log(config.getAlphabet());
 
             alphabetInput.value = "";
 
-            updateAlphabetLabel(alphabetLabel);
             // Notify the React page so it can show a toast confirming the alphabet updated
             showToast("Alphabet Updated!");
           }

--- a/finite-automata-designer/public/scripts/canvasUtil/fsmCanvas.ts
+++ b/finite-automata-designer/public/scripts/canvasUtil/fsmCanvas.ts
@@ -36,8 +36,6 @@ export interface FsmCanvasConfig {
   canvasId: string;
   // id of the Run button for this automaton's page
   runBtnId: string;
-  // Name of the CustomEvent the page listens to for alphabet changes
-  alphabetUpdatedEventName: string;
   // Runs the automaton against an input string
   runAlgo: (input: string) => void;
   // Validates/commits a finished transition label. Returns false when rejected.
@@ -46,6 +44,7 @@ export interface FsmCanvasConfig {
   // be read through getters rather than captured once.
   getAlphabet: () => Set<string>;
   setAlphabet: (alphabet: Set<string>) => void;
+  dispatchAlphabetUpdated: () => void;
   getValidator: () => TransitionLabelInputValidator;
   // Builds the importer used to load an exported SVG/LaTeX document
   createImporter: (
@@ -500,19 +499,6 @@ export function initFsmCanvas(config: FsmCanvasConfig) {
     }
   }
 
-  // This event notifies the page that the alphabet has been updated.
-  // This lets the page know if it needs to check for multi-character
-  // elements in the alphabet, in which case it will show a disclaimer to
-  // the user on how to submit input strings properly.
-  function dispatchAlphabetUpdated() {
-    window.dispatchEvent(new CustomEvent(config.alphabetUpdatedEventName, {
-        detail: {
-          alphabet: Array.from(config.getAlphabet())
-        }
-      })
-    );
-  }
-
   function importHelper(
     canvas: HTMLCanvasElement | null,
     drawImportBtn: HTMLButtonElement | null,
@@ -547,7 +533,7 @@ export function initFsmCanvas(config: FsmCanvasConfig) {
         }
       }
       updateAlphabetLabel(alphabetLabel);
-      dispatchAlphabetUpdated();
+      config.dispatchAlphabetUpdated();
     }
   }
 
@@ -686,7 +672,7 @@ export function initFsmCanvas(config: FsmCanvasConfig) {
 
             config.setAlphabet(new Set(normalized));
 
-            dispatchAlphabetUpdated();
+            config.dispatchAlphabetUpdated();
 
             console.log(config.getAlphabet());
 

--- a/finite-automata-designer/public/scripts/dfsm/dfsmCanvas.ts
+++ b/finite-automata-designer/public/scripts/dfsm/dfsmCanvas.ts
@@ -56,6 +56,18 @@ window.exportDFSM = function(){
   );
 }
 
+window.clearDFSMCanvas = function () {
+    const canvas = document.getElementById(
+        "DFSMCanvas"
+    ) as HTMLCanvasElement | null;
+
+    if (!canvas) {
+        return;
+    }
+
+    clearAutomaton(canvas);
+};
+
 initFsmCanvas({
   automatonLabel: "DFSM",
   canvasId: "DFSMCanvas",

--- a/finite-automata-designer/public/scripts/dfsm/dfsmCanvas.ts
+++ b/finite-automata-designer/public/scripts/dfsm/dfsmCanvas.ts
@@ -81,6 +81,10 @@ window.resetDFSMEditor = function () {
 
 };
 
+window.getDFSMAlphabet = function() {
+  return Array.from(alphabet);
+}
+
 initFsmCanvas({
   automatonLabel: "DFSM",
   canvasId: "DFSMCanvas",

--- a/finite-automata-designer/public/scripts/dfsm/dfsmCanvas.ts
+++ b/finite-automata-designer/public/scripts/dfsm/dfsmCanvas.ts
@@ -56,7 +56,7 @@ window.exportDFSM = function(){
   );
 }
 
-window.clearDFSMCanvas = function () {
+window.resetDFSMEditor = function () {
     const canvas = document.getElementById(
         "DFSMCanvas"
     ) as HTMLCanvasElement | null;
@@ -65,7 +65,20 @@ window.clearDFSMCanvas = function () {
         return;
     }
 
-    clearAutomaton(canvas);
+    clearAutomaton(canvas, drawRef ?? undefined);
+
+    setAlphabet(new Set(["0", "1"]));
+
+    dispatchAlphabetUpdated();
+
+    const alphabetLabel = document.getElementById(
+        "alphabetLabel"
+    ) as HTMLLabelElement | null;
+
+    if (alphabetLabel) {
+        alphabetLabel.textContent = "Alphabet: {0,1}";
+    }
+
 };
 
 initFsmCanvas({

--- a/finite-automata-designer/public/scripts/dfsm/dfsmCanvas.ts
+++ b/finite-automata-designer/public/scripts/dfsm/dfsmCanvas.ts
@@ -35,17 +35,9 @@ let drawRef: (() => void) | null = null;
 // Automaton data that arrived before the canvas finished mounting.
 let pendingDFSM: SerializedFA | null = null;
 
-
-// The ID of the project currently loaded into this editor.
-// Null means we're editing a new/unsaved automaton.
-let currentProjectId: string | null = null;
-
 window.loadDFSMIntoCanvas = function(
-  projectId: string | null, 
   data: SerializedFA
 ){
-
-  currentProjectId = projectId;
 
   if(!drawRef){
     pendingDFSM = data;
@@ -53,10 +45,6 @@ window.loadDFSMIntoCanvas = function(
   }
 
   loadSerializedDFSM(data);
-}
-
-window.getCurrentDFSMProjectId = function(){
-  return currentProjectId;
 }
 
 window.exportDFSM = function(){

--- a/finite-automata-designer/public/scripts/dfsm/dfsmCanvas.ts
+++ b/finite-automata-designer/public/scripts/dfsm/dfsmCanvas.ts
@@ -58,11 +58,12 @@ initFsmCanvas({
   automatonLabel: "DFSM",
   canvasId: "DFSMCanvas",
   runBtnId: "dfsmRunBtn",
-  alphabetUpdatedEventName: "dfsmAlphabetUpdated",
+  //alphabetUpdatedEventName: "dfsmAlphabetUpdated",
   runAlgo: dfsmAlgo,
   commitTransition: transitionDeterminismCheck,
   getAlphabet: () => alphabet,
   setAlphabet,
+  dispatchAlphabetUpdated,
   getValidator: () => transitionLabelInputValidator,
   createImporter: (circs, arrs, data, draw) => new Importer(circs, arrs, data, draw),
   onCanvasReady: (draw) => {
@@ -94,10 +95,24 @@ function loadSerializedDFSM(data: SerializedFA){
   const alphabetLabel = document.getElementById("alphabetLabel") as HTMLLabelElement | null;
   if(alphabetLabel){
     alphabetLabel.textContent = "Alphabet: {"+Array.from(alphabet).join(",")+"}";
+    dispatchAlphabetUpdated();
   }
 
   if(drawRef){
     drawRef();
   }
 
+}
+
+// This event notifies the page that the alphabet has been updated.
+// This lets the page know if it needs to check for multi-character
+// elements in the alphabet, in which case it will show a disclaimer to
+// the user on how to submit input strings properly.
+function dispatchAlphabetUpdated() {
+  window.dispatchEvent(new CustomEvent("dfsmAlphabetUpdated", {
+      detail: {
+        alphabet: Array.from(alphabet)
+      }
+    })
+  );
 }

--- a/finite-automata-designer/public/scripts/dfsm/dfsmCanvas.ts
+++ b/finite-automata-designer/public/scripts/dfsm/dfsmCanvas.ts
@@ -35,7 +35,17 @@ let drawRef: (() => void) | null = null;
 // Automaton data that arrived before the canvas finished mounting.
 let pendingDFSM: SerializedFA | null = null;
 
-window.loadDFSMIntoCanvas = function(data: SerializedFA){
+
+// The ID of the project currently loaded into this editor.
+// Null means we're editing a new/unsaved automaton.
+let currentProjectId: string | null = null;
+
+window.loadDFSMIntoCanvas = function(
+  projectId: string | null, 
+  data: SerializedFA
+){
+
+  currentProjectId = projectId;
 
   if(!drawRef){
     pendingDFSM = data;
@@ -43,6 +53,10 @@ window.loadDFSMIntoCanvas = function(data: SerializedFA){
   }
 
   loadSerializedDFSM(data);
+}
+
+window.getCurrentDFSMProjectId = function(){
+  return currentProjectId;
 }
 
 window.exportDFSM = function(){

--- a/finite-automata-designer/public/scripts/ndfsm/ndfsmCanvas.ts
+++ b/finite-automata-designer/public/scripts/ndfsm/ndfsmCanvas.ts
@@ -52,6 +52,18 @@ window.exportNDFSM = function(){
   );
 }
 
+window.clearNDFSMCanvas = function () {
+    const canvas = document.getElementById(
+        "NDFSMCanvas"
+    ) as HTMLCanvasElement | null;
+
+    if (!canvas) {
+        return;
+    }
+
+    clearAutomaton(canvas);
+};
+
 initFsmCanvas({
   automatonLabel: "NDFSM",
   canvasId: "NDFSMCanvas",

--- a/finite-automata-designer/public/scripts/ndfsm/ndfsmCanvas.ts
+++ b/finite-automata-designer/public/scripts/ndfsm/ndfsmCanvas.ts
@@ -52,7 +52,7 @@ window.exportNDFSM = function(){
   );
 }
 
-window.clearNDFSMCanvas = function () {
+window.resetNDFSMEditor = function () {
     const canvas = document.getElementById(
         "NDFSMCanvas"
     ) as HTMLCanvasElement | null;
@@ -61,7 +61,20 @@ window.clearNDFSMCanvas = function () {
         return;
     }
 
-    clearAutomaton(canvas);
+    clearAutomaton(canvas, drawRef ?? undefined);
+
+    setAlphabet(new Set(["0", "1"]));
+
+    dispatchAlphabetUpdated();
+
+    const alphabetLabel = document.getElementById(
+        "alphabetLabel"
+    ) as HTMLLabelElement | null;
+
+    if (alphabetLabel) {
+        alphabetLabel.textContent = "Alphabet: {0,1}";
+    }
+
 };
 
 initFsmCanvas({

--- a/finite-automata-designer/public/scripts/ndfsm/ndfsmCanvas.ts
+++ b/finite-automata-designer/public/scripts/ndfsm/ndfsmCanvas.ts
@@ -53,11 +53,11 @@ initFsmCanvas({
   automatonLabel: "NDFSM",
   canvasId: "NDFSMCanvas",
   runBtnId: "ndfsmRunBtn",
-  alphabetUpdatedEventName: "ndfsmAlphabetUpdated",
   runAlgo: ndfsmAlgo,
   commitTransition,
   getAlphabet: () => alphabet,
   setAlphabet,
+  dispatchAlphabetUpdated,
   getValidator: () => transitionLabelInputValidator,
   createImporter: (circs, arrs, data, draw) => new Importer(circs, arrs, data, draw),
   onCanvasReady: (draw) => {
@@ -90,9 +90,23 @@ function loadSerializedNDFSM(data: SerializedFA){
 
   if(alphabetLabel){
     alphabetLabel.textContent = "Alphabet: {"+Array.from(alphabet).join(",")+"}";
+    dispatchAlphabetUpdated();
   }
 
   if(drawRef){
     drawRef();
   }
+}
+
+// This event notifies the page that the alphabet has been updated.
+// This lets the page know if it needs to check for multi-character
+// elements in the alphabet, in which case it will show a disclaimer to
+// the user on how to submit input strings properly.
+function dispatchAlphabetUpdated() {
+  window.dispatchEvent(new CustomEvent("ndfsmAlphabetUpdated", {
+      detail: {
+        alphabet: Array.from(alphabet)
+      }
+    })
+  );
 }

--- a/finite-automata-designer/public/scripts/ndfsm/ndfsmCanvas.ts
+++ b/finite-automata-designer/public/scripts/ndfsm/ndfsmCanvas.ts
@@ -31,13 +31,24 @@ let drawRef: (() => void) | null = null;
 
 let pendingNDFSM: SerializedFA | null = null;
 
-window.loadNDFSMIntoCanvas = function(data: SerializedFA){
+let currentProjectId: string | null = null;
+
+window.loadNDFSMIntoCanvas = function(
+  projectId: string | null,
+  data: SerializedFA
+){
+  currentProjectId = projectId;
+
   if(!drawRef){
     pendingNDFSM = data;
     return;
   }
 
   loadSerializedNDFSM(data);
+}
+
+window.getCurrentNDFSMProjectId = function(){
+  return currentProjectId;
 }
 
 window.exportNDFSM = function(){

--- a/finite-automata-designer/public/scripts/ndfsm/ndfsmCanvas.ts
+++ b/finite-automata-designer/public/scripts/ndfsm/ndfsmCanvas.ts
@@ -31,13 +31,9 @@ let drawRef: (() => void) | null = null;
 
 let pendingNDFSM: SerializedFA | null = null;
 
-let currentProjectId: string | null = null;
-
 window.loadNDFSMIntoCanvas = function(
-  projectId: string | null,
   data: SerializedFA
 ){
-  currentProjectId = projectId;
 
   if(!drawRef){
     pendingNDFSM = data;
@@ -45,10 +41,6 @@ window.loadNDFSMIntoCanvas = function(
   }
 
   loadSerializedNDFSM(data);
-}
-
-window.getCurrentNDFSMProjectId = function(){
-  return currentProjectId;
 }
 
 window.exportNDFSM = function(){

--- a/finite-automata-designer/public/scripts/ndfsm/ndfsmCanvas.ts
+++ b/finite-automata-designer/public/scripts/ndfsm/ndfsmCanvas.ts
@@ -77,6 +77,10 @@ window.resetNDFSMEditor = function () {
 
 };
 
+window.getNDFSMAlphabet = function() {
+    return Array.from(alphabet);
+};
+
 initFsmCanvas({
   automatonLabel: "NDFSM",
   canvasId: "NDFSMCanvas",

--- a/finite-automata-designer/src/app/components/editor/AutomataEditor.tsx
+++ b/finite-automata-designer/src/app/components/editor/AutomataEditor.tsx
@@ -307,13 +307,9 @@ export default function AutomataEditor({ type }: AutomataEditorProps){
                 // Fires when the script first loads AND after every subsequent
                 // component mount where the script is already cached.
                 // Delivers any automaton data that arrived before the script was ready.
-                if(automatonId){
-                    if (pendingAutomaton.current !== null) {
-                        api.loadFAIntoCanvas(pendingAutomaton.current);
-                        pendingAutomaton.current = null;
-                    }
-
-                    return;
+                if (pendingAutomaton.current !== null) {
+                    api.loadFAIntoCanvas(pendingAutomaton.current);
+                    pendingAutomaton.current = null;
                 }
             }}
         />

--- a/finite-automata-designer/src/app/components/editor/AutomataEditor.tsx
+++ b/finite-automata-designer/src/app/components/editor/AutomataEditor.tsx
@@ -70,6 +70,8 @@ export default function AutomataEditor({ type }: AutomataEditorProps){
 
             const hasMulti = symbols.some(symbol => symbol.length > 1);
             setHasMultiCharAlphabet(hasMulti);
+
+            console.log("Has multi-character alphabet...");
         }
 
         // Ex: dfsmAlphabetUpdated or ndfsmAlphabetUpdated, where "type" is either "DFSM" or "NDFSM"
@@ -80,7 +82,7 @@ export default function AutomataEditor({ type }: AutomataEditorProps){
             window.removeEventListener(`${type.toLowerCase()}AlphabetUpdated`, handler);
         }
 
-    }, [alphabetInput, type]);
+    }, [alphabetInput, type, automatonId]);
 
     // Holds the toast notification subscriber
     useEffect(() => {
@@ -122,7 +124,7 @@ export default function AutomataEditor({ type }: AutomataEditorProps){
 
             if (typeof api.loadFAIntoCanvas === 'function') {
                 // Canvas script is already loaded — call directly.
-                api.loadFAIntoCanvas(finiteAutomatonData.automaton);
+                api.loadFAIntoCanvas(automatonId, finiteAutomatonData.automaton);
             } else {
                 // Canvas script hasn't finished loading yet (production race).
                 // Store the data so the onReady callback can deliver it once ready.
@@ -132,6 +134,20 @@ export default function AutomataEditor({ type }: AutomataEditorProps){
 
         loadAutomaton();
     },[automatonId, api]);
+
+    // useEffect(() => {
+    //     if (automatonId) return;
+
+    //     if (typeof api.getCurrentProjectId !== "function") {
+    //         return;
+    //     }
+
+    //     const projectId = api.getCurrentProjectId();
+
+    //     if (projectId) {
+    //         router.replace(`/${type.toLowerCase()}/${projectId}`);
+    //     }
+    // }, [type, automatonId, api, router]);
 
 
     async function handleSaveAsNew(newName: string, newDescription: string){
@@ -289,9 +305,19 @@ export default function AutomataEditor({ type }: AutomataEditorProps){
                 // Fires when the script first loads AND after every subsequent
                 // component mount where the script is already cached.
                 // Delivers any automaton data that arrived before the script was ready.
-                if (pendingAutomaton.current !== null) {
-                    api.loadFAIntoCanvas(pendingAutomaton.current);
-                    pendingAutomaton.current = null;
+                if(automatonId){
+                    if (pendingAutomaton.current !== null) {
+                        api.loadFAIntoCanvas(automatonId, pendingAutomaton.current);
+                        pendingAutomaton.current = null;
+                    }
+
+                    return;
+                }
+
+                const projectId = api.getCurrentProjectId();
+
+                if(projectId){
+                    router.replace(`/${type.toLowerCase()}?id=${projectId}`);
                 }
             }}
         />

--- a/finite-automata-designer/src/app/components/editor/AutomataEditor.tsx
+++ b/finite-automata-designer/src/app/components/editor/AutomataEditor.tsx
@@ -42,7 +42,6 @@ interface AutomataEditorProps {
 export default function AutomataEditor({ type }: AutomataEditorProps){
 
     const [hasMultiCharAlphabet, setHasMultiCharAlphabet] = useState(false);
-    const [alphabetInput, setAlphabetInput] = useState("");
     const [isSaving, setIsSaving] = useState(false);
     const [name, setName] = useState<string | null>(null);
     const [description, setDescription] = useState<string | null>(null);
@@ -109,9 +108,6 @@ export default function AutomataEditor({ type }: AutomataEditorProps){
             const customEvent = event as CustomEvent<{alphabet: string[]}>;
             const symbols = customEvent.detail.alphabet;
 
-            const alphabetString = symbols.join(',');
-            setAlphabetInput(alphabetString);
-
             const hasMulti = symbols.some(symbol => symbol.length > 1);
             setHasMultiCharAlphabet(hasMulti);
 
@@ -126,7 +122,7 @@ export default function AutomataEditor({ type }: AutomataEditorProps){
             window.removeEventListener(`${type.toLowerCase()}AlphabetUpdated`, handler);
         }
 
-    }, [alphabetInput, type, automatonId]);
+    }, [type]);
 
     // Holds the toast notification subscriber
     useEffect(() => {

--- a/finite-automata-designer/src/app/components/editor/AutomataEditor.tsx
+++ b/finite-automata-designer/src/app/components/editor/AutomataEditor.tsx
@@ -49,6 +49,7 @@ export default function AutomataEditor({ type }: AutomataEditorProps){
     const router = useRouter();
     const searchParams = useSearchParams();
     const automatonId = searchParams?.get("id") as string;
+    const isNewProject = (searchParams?.get("new") === "true") as boolean;
 
     const title: string = type === "DFSM" ? "Deterministic Finite State Machine" : "Non-Deterministic Finite State Machine";
 
@@ -141,7 +142,7 @@ export default function AutomataEditor({ type }: AutomataEditorProps){
     },[automatonId, api, type]);
 
     useEffect(() => {
-        if (automatonId) return;
+        if (automatonId || isNewProject) return;
 
         const projectId = sessionStorage.getItem(
             `${type.toLowerCase()}-current-project`
@@ -150,7 +151,7 @@ export default function AutomataEditor({ type }: AutomataEditorProps){
         if (projectId) {
             router.replace(`/${type.toLowerCase()}?id=${projectId}`);
         }
-    }, [type, automatonId, router]);
+    }, [type, automatonId, isNewProject, router]);
 
     async function handleSaveAsNew(newName: string, newDescription: string){
     

--- a/finite-automata-designer/src/app/components/editor/AutomataEditor.tsx
+++ b/finite-automata-designer/src/app/components/editor/AutomataEditor.tsx
@@ -101,18 +101,21 @@ export default function AutomataEditor({ type }: AutomataEditorProps){
         router
     ]);
 
+
+    function syncAlphabet(symbols: string[]) {
+        setHasMultiCharAlphabet(
+            symbols.some(symbol => symbol.length > 1)
+        );
+    }
+
     useEffect(() => {
 
         // This will listen for alphabet updates from the canvas script
         const handler = (event: Event) => {
-            const customEvent = event as CustomEvent<{alphabet: string[]}>;
-            const symbols = customEvent.detail.alphabet;
+            const customEvent = event as CustomEvent<{ alphabet: string[] }>;
 
-            const hasMulti = symbols.some(symbol => symbol.length > 1);
-            setHasMultiCharAlphabet(hasMulti);
-
-            console.log("Has multi-character alphabet...");
-        }
+            syncAlphabet(customEvent.detail.alphabet);
+        };
 
         // Ex: dfsmAlphabetUpdated or ndfsmAlphabetUpdated, where "type" is either "DFSM" or "NDFSM"
         window.addEventListener(`${type.toLowerCase()}AlphabetUpdated`, handler);
@@ -367,6 +370,11 @@ export default function AutomataEditor({ type }: AutomataEditorProps){
                     api.loadFAIntoCanvas(pendingAutomaton.current);
                     pendingAutomaton.current = null;
                 }
+                else{
+                    // Synchronize React with the current alphabet now that the
+                    // canvas API definitely exists.
+                    syncAlphabet(api.getAlphabet());
+                }   
             }}
         />
       </main>

--- a/finite-automata-designer/src/app/components/editor/AutomataEditor.tsx
+++ b/finite-automata-designer/src/app/components/editor/AutomataEditor.tsx
@@ -51,6 +51,7 @@ export default function AutomataEditor({ type }: AutomataEditorProps){
     const router = useRouter();
     const searchParams = useSearchParams();
     const automatonId = searchParams?.get("id") as string;
+    const isNewProject = (searchParams?.get("new") === "true") as boolean;
 
     const title: string = type === "DFSM" ? "Deterministic Finite State Machine" : "Non-Deterministic Finite State Machine";
 
@@ -142,6 +143,15 @@ export default function AutomataEditor({ type }: AutomataEditorProps){
         loadAutomaton();
     },[automatonId, api, type]);
 
+    useEffect(() => {
+        if (!isNewProject) return;
+
+        setEditorSession(type, {
+            mode: "new"
+        });
+
+    }, [automatonId, api, isNewProject, type]);
+
     async function handleSaveAsNew(newName: string, newDescription: string){
     
         const serialized = api.exportFA();
@@ -174,6 +184,19 @@ export default function AutomataEditor({ type }: AutomataEditorProps){
             showToast("Save failed.", { color: "red", duration: 6000 });
         }
     }
+
+    const handleNewProject = () => {
+        setEditorSession(type, {
+            mode: "new",
+        });
+
+        setName(null);
+        setDescription("");
+
+        api.clearCanvas();
+
+        router.push(`/${type.toLowerCase()}?new=true`);
+    };
 
     return (
       <main className="min-h-screen bg-blue-100 flex flex-col items-center">
@@ -273,7 +296,7 @@ export default function AutomataEditor({ type }: AutomataEditorProps){
                     </div>
                     <div>
                         <NewProjectButton
-                            type={type}
+                            handleNewProject={handleNewProject}
                         />
                     </div>
 

--- a/finite-automata-designer/src/app/components/editor/AutomataEditor.tsx
+++ b/finite-automata-designer/src/app/components/editor/AutomataEditor.tsx
@@ -24,6 +24,7 @@ import BackButton from "./BackButton";
 import SaveActions from './SaveActions';
 import SaveProjectModal from "../projects/SaveProjectModal";
 import ToastNotification, { SHOW_TOAST_EVENT, ShowToastDetail, showToast } from "../misc/ToastNotification";
+import NewProjectButton from './NewProjectButton';
 
 {/* Database/Serialization */}
 import { SerializedFA } from '@/lib/shared/types';
@@ -32,7 +33,6 @@ import { getAutomaton } from '@/lib/automata/queries';
 import { saveAutomaton, updateAutomaton } from "@/lib/automata/mutations";
 
 import { automataApi } from './api/automataApi';
-import NewProjectButton from './NewProjectButton';
 import { getEditorSession, setEditorSession } from '@/lib/editorSession';
 
 interface AutomataEditorProps {

--- a/finite-automata-designer/src/app/components/editor/AutomataEditor.tsx
+++ b/finite-automata-designer/src/app/components/editor/AutomataEditor.tsx
@@ -32,6 +32,8 @@ import { getAutomaton } from '@/lib/automata/queries';
 import { saveAutomaton, updateAutomaton } from "@/lib/automata/mutations";
 
 import { automataApi } from './api/automataApi';
+import NewProjectButton from './NewProjectButton';
+import { setEditorSession } from '@/lib/editorSession';
 
 interface AutomataEditorProps {
     type: "DFSM" | "NDFSM";
@@ -49,7 +51,6 @@ export default function AutomataEditor({ type }: AutomataEditorProps){
     const router = useRouter();
     const searchParams = useSearchParams();
     const automatonId = searchParams?.get("id") as string;
-    const isNewProject = (searchParams?.get("new") === "true") as boolean;
 
     const title: string = type === "DFSM" ? "Deterministic Finite State Machine" : "Non-Deterministic Finite State Machine";
 
@@ -124,10 +125,10 @@ export default function AutomataEditor({ type }: AutomataEditorProps){
             setDescription(finiteAutomatonData.description);
 
             if (typeof api.loadFAIntoCanvas === 'function') {
-                sessionStorage.setItem(
-                    `${type.toLowerCase()}-current-project`,
-                    automatonId
-                );
+                setEditorSession(type, {
+                    mode: "saved",
+                    projectId: automatonId
+                });
 
                 // Canvas script is already loaded — call directly.
                 api.loadFAIntoCanvas(finiteAutomatonData.automaton);
@@ -140,18 +141,6 @@ export default function AutomataEditor({ type }: AutomataEditorProps){
 
         loadAutomaton();
     },[automatonId, api, type]);
-
-    useEffect(() => {
-        if (automatonId || isNewProject) return;
-
-        const projectId = sessionStorage.getItem(
-            `${type.toLowerCase()}-current-project`
-        );
-
-        if (projectId) {
-            router.replace(`/${type.toLowerCase()}?id=${projectId}`);
-        }
-    }, [type, automatonId, isNewProject, router]);
 
     async function handleSaveAsNew(newName: string, newDescription: string){
     
@@ -282,6 +271,12 @@ export default function AutomataEditor({ type }: AutomataEditorProps){
 
                         </div>
                     </div>
+                    <div>
+                        <NewProjectButton
+                            type={type}
+                        />
+                    </div>
+
                     {/* Clear Canvas parent container */}
                     <div>
                         <ClearCanvasButton />

--- a/finite-automata-designer/src/app/components/editor/AutomataEditor.tsx
+++ b/finite-automata-designer/src/app/components/editor/AutomataEditor.tsx
@@ -33,7 +33,7 @@ import { saveAutomaton, updateAutomaton } from "@/lib/automata/mutations";
 
 import { automataApi } from './api/automataApi';
 import NewProjectButton from './NewProjectButton';
-import { setEditorSession } from '@/lib/editorSession';
+import { getEditorSession, setEditorSession } from '@/lib/editorSession';
 
 interface AutomataEditorProps {
     type: "DFSM" | "NDFSM";
@@ -60,6 +60,47 @@ export default function AutomataEditor({ type }: AutomataEditorProps){
     // Holds automaton data fetched before the canvas script has finished loading.
     // onReady on the <Script> tag drains this once the script is ready.
     const pendingAutomaton = useRef<SerializedFA | null>(null);
+
+    useEffect(() => {
+        if (automatonId || isNewProject) {
+            return;
+        }
+
+        const session = getEditorSession(type);
+
+        if (!session) {
+            router.replace(
+                `/${type.toLowerCase()}?new=true`
+            );
+
+            return;
+        }
+
+
+        if (
+            session.mode === "saved" &&
+            session.projectId
+        ) {
+            router.replace(
+                `/${type.toLowerCase()}?id=${session.projectId}`
+            );
+
+            return;
+        }
+
+
+        if (session.mode === "new") {
+            router.replace(
+                `/${type.toLowerCase()}?new=true`
+            );
+        }
+
+    }, [
+        type,
+        automatonId,
+        isNewProject,
+        router
+    ]);
 
     useEffect(() => {
 

--- a/finite-automata-designer/src/app/components/editor/AutomataEditor.tsx
+++ b/finite-automata-designer/src/app/components/editor/AutomataEditor.tsx
@@ -234,7 +234,7 @@ export default function AutomataEditor({ type }: AutomataEditorProps){
         setName(null);
         setDescription("");
 
-        api.clearCanvas();
+        api.resetEditor();
 
         router.push(`/${type.toLowerCase()}?new=true`);
     };

--- a/finite-automata-designer/src/app/components/editor/AutomataEditor.tsx
+++ b/finite-automata-designer/src/app/components/editor/AutomataEditor.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-'use client';
-
 {/* Script */}
 import Script from 'next/script';
 

--- a/finite-automata-designer/src/app/components/editor/AutomataEditor.tsx
+++ b/finite-automata-designer/src/app/components/editor/AutomataEditor.tsx
@@ -123,8 +123,13 @@ export default function AutomataEditor({ type }: AutomataEditorProps){
             setDescription(finiteAutomatonData.description);
 
             if (typeof api.loadFAIntoCanvas === 'function') {
+                sessionStorage.setItem(
+                    `${type.toLowerCase()}-current-project`,
+                    automatonId
+                );
+
                 // Canvas script is already loaded — call directly.
-                api.loadFAIntoCanvas(automatonId, finiteAutomatonData.automaton);
+                api.loadFAIntoCanvas(finiteAutomatonData.automaton);
             } else {
                 // Canvas script hasn't finished loading yet (production race).
                 // Store the data so the onReady callback can deliver it once ready.
@@ -133,22 +138,19 @@ export default function AutomataEditor({ type }: AutomataEditorProps){
         }
 
         loadAutomaton();
-    },[automatonId, api]);
+    },[automatonId, api, type]);
 
-    // useEffect(() => {
-    //     if (automatonId) return;
+    useEffect(() => {
+        if (automatonId) return;
 
-    //     if (typeof api.getCurrentProjectId !== "function") {
-    //         return;
-    //     }
+        const projectId = sessionStorage.getItem(
+            `${type.toLowerCase()}-current-project`
+        );
 
-    //     const projectId = api.getCurrentProjectId();
-
-    //     if (projectId) {
-    //         router.replace(`/${type.toLowerCase()}/${projectId}`);
-    //     }
-    // }, [type, automatonId, api, router]);
-
+        if (projectId) {
+            router.replace(`/${type.toLowerCase()}?id=${projectId}`);
+        }
+    }, [type, automatonId, router]);
 
     async function handleSaveAsNew(newName: string, newDescription: string){
     
@@ -307,17 +309,11 @@ export default function AutomataEditor({ type }: AutomataEditorProps){
                 // Delivers any automaton data that arrived before the script was ready.
                 if(automatonId){
                     if (pendingAutomaton.current !== null) {
-                        api.loadFAIntoCanvas(automatonId, pendingAutomaton.current);
+                        api.loadFAIntoCanvas(pendingAutomaton.current);
                         pendingAutomaton.current = null;
                     }
 
                     return;
-                }
-
-                const projectId = api.getCurrentProjectId();
-
-                if(projectId){
-                    router.replace(`/${type.toLowerCase()}?id=${projectId}`);
                 }
             }}
         />

--- a/finite-automata-designer/src/app/components/editor/NewProjectButton.tsx
+++ b/finite-automata-designer/src/app/components/editor/NewProjectButton.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { setEditorSession } from "@/lib/editorSession";
+import { useRouter } from "next/navigation";
+
+interface NewProjectButtonProps {
+    type: "DFSM" | "NDFSM";
+}
+
+export default function NewProjectButton({
+    type,
+}: NewProjectButtonProps) {
+    const router = useRouter();
+
+    const handleNewProject = () => {
+        setEditorSession(type, {
+            mode: "new"
+        });
+
+        router.push(`/${type.toLowerCase()}?new=true`);
+    };
+
+    return (
+        <button
+            onClick={handleNewProject}
+            className="flex px-8 py-3 bg-gray-700 text-white rounded hover:bg-black transition"
+        >
+            New Project
+        </button>
+    );
+}

--- a/finite-automata-designer/src/app/components/editor/NewProjectButton.tsx
+++ b/finite-automata-designer/src/app/components/editor/NewProjectButton.tsx
@@ -1,24 +1,12 @@
 "use client";
 
-import { setEditorSession } from "@/lib/editorSession";
-import { useRouter } from "next/navigation";
-
 interface NewProjectButtonProps {
-    type: "DFSM" | "NDFSM";
+    handleNewProject: () => void;
 }
 
 export default function NewProjectButton({
-    type,
+    handleNewProject,
 }: NewProjectButtonProps) {
-    const router = useRouter();
-
-    const handleNewProject = () => {
-        setEditorSession(type, {
-            mode: "new"
-        });
-
-        router.push(`/${type.toLowerCase()}?new=true`);
-    };
 
     return (
         <button

--- a/finite-automata-designer/src/app/components/editor/api/automataApi.ts
+++ b/finite-automata-designer/src/app/components/editor/api/automataApi.ts
@@ -2,11 +2,13 @@ import { SerializedFA } from "@/lib/shared/types";
 
 export const automataApi = {
     DFSM: {
-        loadFAIntoCanvas: (data: SerializedFA) => window.loadDFSMIntoCanvas(data),
+        loadFAIntoCanvas: (projectId: string | null, data: SerializedFA) => window.loadDFSMIntoCanvas(projectId, data),
         exportFA: () => window.exportDFSM(),
+        getCurrentProjectId: () => window.getCurrentDFSMProjectId(),
     },
     NDFSM: {
-        loadFAIntoCanvas: (data: SerializedFA) => window.loadNDFSMIntoCanvas(data),
+        loadFAIntoCanvas: (projectId: string | null, data: SerializedFA) => window.loadNDFSMIntoCanvas(projectId, data),
         exportFA: () => window.exportNDFSM(),
+        getCurrentProjectId: () => window.getCurrentNDFSMProjectId(),
     },
 } as const;

--- a/finite-automata-designer/src/app/components/editor/api/automataApi.ts
+++ b/finite-automata-designer/src/app/components/editor/api/automataApi.ts
@@ -4,11 +4,19 @@ export const automataApi = {
     DFSM: {
         loadFAIntoCanvas: (data: SerializedFA) => window.loadDFSMIntoCanvas(data),
         exportFA: () => window.exportDFSM(),
-        clearCanvas: () => window.clearDFSMCanvas(),
+        clearCanvas: () => {
+            if (typeof window.clearDFSMCanvas === "function") {
+                window.clearDFSMCanvas();
+            }
+        },
     },
     NDFSM: {
         loadFAIntoCanvas: (data: SerializedFA) => window.loadNDFSMIntoCanvas(data),
         exportFA: () => window.exportNDFSM(),
-        clearCanvas: () => window.clearNDFSMCanvas(),
+        clearCanvas: () => {
+            if (typeof window.clearNDFSMCanvas === "function") {
+                window.clearDFSMCanvas();
+            }
+        },
     },
 } as const;

--- a/finite-automata-designer/src/app/components/editor/api/automataApi.ts
+++ b/finite-automata-designer/src/app/components/editor/api/automataApi.ts
@@ -2,13 +2,11 @@ import { SerializedFA } from "@/lib/shared/types";
 
 export const automataApi = {
     DFSM: {
-        loadFAIntoCanvas: (projectId: string | null, data: SerializedFA) => window.loadDFSMIntoCanvas(projectId, data),
+        loadFAIntoCanvas: (data: SerializedFA) => window.loadDFSMIntoCanvas(data),
         exportFA: () => window.exportDFSM(),
-        getCurrentProjectId: () => window.getCurrentDFSMProjectId(),
     },
     NDFSM: {
-        loadFAIntoCanvas: (projectId: string | null, data: SerializedFA) => window.loadNDFSMIntoCanvas(projectId, data),
+        loadFAIntoCanvas: (data: SerializedFA) => window.loadNDFSMIntoCanvas(data),
         exportFA: () => window.exportNDFSM(),
-        getCurrentProjectId: () => window.getCurrentNDFSMProjectId(),
     },
 } as const;

--- a/finite-automata-designer/src/app/components/editor/api/automataApi.ts
+++ b/finite-automata-designer/src/app/components/editor/api/automataApi.ts
@@ -4,9 +4,11 @@ export const automataApi = {
     DFSM: {
         loadFAIntoCanvas: (data: SerializedFA) => window.loadDFSMIntoCanvas(data),
         exportFA: () => window.exportDFSM(),
+        clearCanvas: () => window.clearDFSMCanvas(),
     },
     NDFSM: {
         loadFAIntoCanvas: (data: SerializedFA) => window.loadNDFSMIntoCanvas(data),
         exportFA: () => window.exportNDFSM(),
+        clearCanvas: () => window.clearNDFSMCanvas(),
     },
 } as const;

--- a/finite-automata-designer/src/app/components/editor/api/automataApi.ts
+++ b/finite-automata-designer/src/app/components/editor/api/automataApi.ts
@@ -4,18 +4,18 @@ export const automataApi = {
     DFSM: {
         loadFAIntoCanvas: (data: SerializedFA) => window.loadDFSMIntoCanvas(data),
         exportFA: () => window.exportDFSM(),
-        clearCanvas: () => {
-            if (typeof window.clearDFSMCanvas === "function") {
-                window.clearDFSMCanvas();
+        resetEditor: () => {
+            if (typeof window.resetDFSMEditor === "function") {
+                window.resetDFSMEditor();
             }
         },
     },
     NDFSM: {
         loadFAIntoCanvas: (data: SerializedFA) => window.loadNDFSMIntoCanvas(data),
         exportFA: () => window.exportNDFSM(),
-        clearCanvas: () => {
-            if (typeof window.clearNDFSMCanvas === "function") {
-                window.clearDFSMCanvas();
+        resetEditor: () => {
+            if (typeof window.resetNDFSMEditor === "function") {
+                window.resetNDFSMEditor();
             }
         },
     },

--- a/finite-automata-designer/src/app/components/editor/api/automataApi.ts
+++ b/finite-automata-designer/src/app/components/editor/api/automataApi.ts
@@ -9,6 +9,14 @@ export const automataApi = {
                 window.resetDFSMEditor();
             }
         },
+        getAlphabet: () => {
+            if(typeof window.getDFSMAlphabet === "function"){
+                return window.getDFSMAlphabet()
+            }
+            else{
+                return [] as string[];
+            }
+        },
     },
     NDFSM: {
         loadFAIntoCanvas: (data: SerializedFA) => window.loadNDFSMIntoCanvas(data),
@@ -16,6 +24,14 @@ export const automataApi = {
         resetEditor: () => {
             if (typeof window.resetNDFSMEditor === "function") {
                 window.resetNDFSMEditor();
+            }
+        },
+        getAlphabet: () => {
+            if(typeof window.getNDFSMAlphabet === "function"){
+                return window.getNDFSMAlphabet()
+            }
+            else{
+                return [] as string[];
             }
         },
     },

--- a/finite-automata-designer/src/app/components/home/EditorButton.tsx
+++ b/finite-automata-designer/src/app/components/home/EditorButton.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { getEditorSession, setEditorSession } from "@/lib/editorSession";
+
+interface EditorButtonProps{
+    type: "DFSM" | "NDFSM";
+}
+
+export default function EditorButton({
+    type,
+}: EditorButtonProps) {
+    const router = useRouter();
+
+    function handleClick() {
+        const session = getEditorSession(type);
+
+        if (!session) {
+            setEditorSession(`${type}`, {
+                mode: "new"
+            });
+
+            router.push(`/${type.toLowerCase()}?new=true`);
+            return;
+        }
+
+        if (
+            session.mode === "saved" &&
+            session.projectId
+        ) {
+            router.push(
+                `/${type.toLowerCase()}?id=${session.projectId}`
+            );
+        }
+        else {
+            router.push(`/${type.toLowerCase()}?new=true`);
+        }
+    }
+
+
+    return (
+        <button 
+            onClick={handleClick}
+            className="px-10 py-5 bg-gray-600 text-2xl text-white rounded hover:bg-black hover:shadow-lg hover:scale-105 transition-transform duration-400"
+        >
+            {type}
+        </button>
+    );
+}

--- a/finite-automata-designer/src/app/page.tsx
+++ b/finite-automata-designer/src/app/page.tsx
@@ -1,4 +1,5 @@
-import Link from "next/link"
+//import Link from "next/link"
+import EditorButton from "./components/home/EditorButton";
 
 export default function Home() {
   return (
@@ -16,18 +17,18 @@ export default function Home() {
         <div className="flex space-x-10">
           
           {/* Button for DFSM */}
-          <Link href="/dfsm" passHref>
-            <button className="px-10 py-5 bg-gray-600 text-2xl text-white rounded hover:bg-black hover:shadow-lg hover:scale-105 transition-transform duration-400">
-              DFSM
-            </button>
-          </Link>
+          {/* <Link href="/dfsm" passHref> */}
+            <EditorButton 
+              type="DFSM"
+            />
+          {/* </Link> */}
 
           {/* Button for NDFSM */}
-          <Link href="/ndfsm" passHref>
-            <button className="px-10 py-5 bg-gray-600 text-2xl text-white rounded hover:bg-black hover:shadow-lg hover:scale-105 transition-transform duration-400">
-              NDFSM
-            </button>
-          </Link>
+          {/* <Link href="/ndfsm" passHref> */}
+            <EditorButton 
+              type="NDFSM"
+            />
+          {/* </Link> */}
         </div>
       </div>
     </main>

--- a/finite-automata-designer/src/lib/editorSession.ts
+++ b/finite-automata-designer/src/lib/editorSession.ts
@@ -1,0 +1,35 @@
+import { EditorSession } from "@/types/editorSession";
+
+export function getEditorSession(type: "DFSM" | "NDFSM") {
+    const key = `${type.toLowerCase()}-session`;
+
+    const stored = sessionStorage.getItem(key);
+
+    if (!stored) {
+        return null;
+    }
+
+    return JSON.parse(stored) as EditorSession;
+}
+
+
+export function setEditorSession(
+    type: "DFSM" | "NDFSM",
+    session: EditorSession
+) {
+    const key = `${type.toLowerCase()}-session`;
+
+    sessionStorage.setItem(
+        key,
+        JSON.stringify(session)
+    );
+}
+
+
+export function clearEditorSession(
+    type: "DFSM" | "NDFSM"
+) {
+    const key = `${type.toLowerCase()}-session`;
+
+    sessionStorage.removeItem(key);
+}

--- a/finite-automata-designer/src/types/editorSession.ts
+++ b/finite-automata-designer/src/types/editorSession.ts
@@ -1,0 +1,4 @@
+export interface EditorSession {
+    mode: "saved" | "new";
+    projectId?: string;
+}

--- a/finite-automata-designer/src/types/global.d.ts
+++ b/finite-automata-designer/src/types/global.d.ts
@@ -14,8 +14,17 @@ declare global {
     /** Serializes the current NDFSM canvas state and returns it. */
     exportNDFSM: () => SerializedFA;
 
+    /** Resets the DFSM editor by erasing canvas and alphabet */
     resetDFSMEditor: () => void;
+
+    /** Resets the NDFSM editor by erasing canvas and alphabet */
     resetNDFSMEditor: () => void;
+
+    /** Gets the DFSM alphabet */
+    getDFSMAlphabet: () => string[];
+
+    /** Gets the NDFSM alphabet */
+    getNDFSMAlphabet: () => string[];
 
   }
 }

--- a/finite-automata-designer/src/types/global.d.ts
+++ b/finite-automata-designer/src/types/global.d.ts
@@ -14,5 +14,8 @@ declare global {
     /** Serializes the current NDFSM canvas state and returns it. */
     exportNDFSM: () => SerializedFA;
 
+    clearDFSMCanvas: () => void;
+    clearNDFSMCanvas: () => void;
+
   }
 }

--- a/finite-automata-designer/src/types/global.d.ts
+++ b/finite-automata-designer/src/types/global.d.ts
@@ -14,8 +14,8 @@ declare global {
     /** Serializes the current NDFSM canvas state and returns it. */
     exportNDFSM: () => SerializedFA;
 
-    clearDFSMCanvas: () => void;
-    clearNDFSMCanvas: () => void;
+    resetDFSMEditor: () => void;
+    resetNDFSMEditor: () => void;
 
   }
 }

--- a/finite-automata-designer/src/types/global.d.ts
+++ b/finite-automata-designer/src/types/global.d.ts
@@ -3,16 +3,21 @@ export {};
 declare global {
   interface Window {
     /** Loads a serialized automaton object into the DFSM canvas. */
-    loadDFSMIntoCanvas: (automaton: SerializedFA) => void;
+    loadDFSMIntoCanvas: (projectId: string | null, automaton: SerializedFA) => void;
 
     /** Loads a serialized automaton object into the NDFSM canvas. */
-    loadNDFSMIntoCanvas: (automaton: SerializedFA) => void;
+    loadNDFSMIntoCanvas: (projectId: string | null, automaton: SerializedFA) => void;
 
     /** Serializes the current DFSM canvas state and returns it. */
     exportDFSM: () => SerializedFA;
 
     /** Serializes the current NDFSM canvas state and returns it. */
     exportNDFSM: () => SerializedFA;
+
+
+    getCurrentDFSMProjectId: () => (string | null);
+
+    getCurrentNDFSMProjectId: () => (string | null);
 
   }
 }

--- a/finite-automata-designer/src/types/global.d.ts
+++ b/finite-automata-designer/src/types/global.d.ts
@@ -3,21 +3,16 @@ export {};
 declare global {
   interface Window {
     /** Loads a serialized automaton object into the DFSM canvas. */
-    loadDFSMIntoCanvas: (projectId: string | null, automaton: SerializedFA) => void;
+    loadDFSMIntoCanvas: (automaton: SerializedFA) => void;
 
     /** Loads a serialized automaton object into the NDFSM canvas. */
-    loadNDFSMIntoCanvas: (projectId: string | null, automaton: SerializedFA) => void;
+    loadNDFSMIntoCanvas: (automaton: SerializedFA) => void;
 
     /** Serializes the current DFSM canvas state and returns it. */
     exportDFSM: () => SerializedFA;
 
     /** Serializes the current NDFSM canvas state and returns it. */
     exportNDFSM: () => SerializedFA;
-
-
-    getCurrentDFSMProjectId: () => (string | null);
-
-    getCurrentNDFSMProjectId: () => (string | null);
 
   }
 }


### PR DESCRIPTION
### Objective: Resolve the issues mentioned below and implement project session management to restore editor states across navigation
- [x] Fixed the routing issue where returning to an editor now restores the correct project URL if the user was previously working on a saved project
- [x] Used React's sessionStorage object to handle project session management
  - For example, let's say the user was on dfsm?new=true, and then they leave the DFSM editor
  - Then, returning to the DFSM editor via the homepage will return them to that same URL
  - This holds true for saved projects as well: if the user was on dfsm?id=123, and then return to the DFSM editor via the homepage, they will return to dfsm?id=123
- [x] Typing in dfsm/ or ndfsm/ into the URL will redirect you to the saved project you were previously working on. If you were not working on a saved project, then you will be redirected to a blank canvas
  - See the Future Considerations section below for an unresolved edge case regarding this feature
- [x] Added "New Project" button, which redirects the user to a blank project page with the default alphabet of "0" and "1"
- [x] Introduced editor session concept via query params 
  - Specifically, "?new=true" parameter in the URL, which indicates a new, unsaved project
- [x] Exposed resetEditor API on the DFSM and NDFSM canvases to properly clear the editor
- [x] Exposed getAlphabet API on the DFSM and NDFSM canvases to correctly display the multi-character alphabet disclaimer when appropriate
- [x] The title and description are properly reset when creating a new project

### Issues Resolved
- [x] #54 
- [x] #75 
  - [x] #76 
  - [x] #77 
- [x] #78 

### Bugs:
- #79 

### Future Considerations
- If you were working on an unsaved project and you were to type dfsm/ or ndfsm/ into the URL, then you will be redirected to a blank canvas, not the unsaved project you were working on
  - Resolving this would require storing the current FSM in the sessionStorage object, which would like require an implementation of dirty states
  - However, this may not necessarily need to be resolved right now
  - Reloading your most recent project, whether saved or unsaved, is mainly done when the user accesses either the DFSM or NDFSM editor via the buttons on the _homepage_
  - Reloading your most recent project when simply typing dfsm/ or ndfsm/ into the URL will only work if your most recent project was saved to the database
  - So, to reiterate the problem, the issue is that typing dfsm/ or ndfsm/ into the URL when your most recent project was unsaved _will not_ reload that unsaved project. This might not necessarily need to be resolved, as the user will likely only access the editors via the two homepage buttons or through the Projects page